### PR TITLE
chore: 外向け表示名と package 名を `miku-xlsx2md` に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Mikuku's xlsx2md
+# miku-xlsx2md
 
-![Mikuku's xlsx2md OGP](docs/screenshots/xlsx2md-ogp.png)
+![miku-xlsx2md OGP](docs/screenshots/xlsx2md-ogp.png)
+
+miku-xlsx2md is one of the tools in Mikuku's software series.
 
 ## What is this?
 
-`Mikuku's xlsx2md` is a single-file web app that reads Excel (`.xlsx`) files locally and extracts prose, tables, and images as Markdown.
+`miku-xlsx2md` is a single-file web app that reads Excel (`.xlsx`) files locally and extracts prose, tables, and images as Markdown.
 
 - Runs entirely in the browser with no server communication
 - Converts the whole workbook automatically without sheet-by-sheet manual work
@@ -28,9 +30,9 @@
 
 ## Feature Support Overview
 
-`Mikuku's xlsx2md` prioritizes extracting workbook content into meaningful Markdown rather than reproducing Excel's visual appearance exactly. The support status for common expectations is as follows.
+`miku-xlsx2md` prioritizes extracting workbook content into meaningful Markdown rather than reproducing Excel's visual appearance exactly. The support status for common expectations is as follows.
 
-| Item | `Mikuku's xlsx2md` status | Notes |
+| Item | `miku-xlsx2md` status | Notes |
 | --- | --- | --- |
 | Read `.xlsx` files | Supported | Runs locally in the browser |
 | Convert a whole workbook in one pass | Supported | Processes all sheets together |
@@ -154,7 +156,7 @@ In the browser UI, `utf-8`, `utf-16le`, `utf-16be`, `utf-32le`, and `utf-32be` s
 - Repository name: `miku-xlsx2md`
 - Published single-file app: `miku-xlsx2md.html`
 - Product / internal name: `xlsx2md`
-- Display name: `Mikuku's xlsx2md`
+- Display name: `miku-xlsx2md`
 
 This repository was moved from `xlsx2md` to `miku-xlsx2md`.
 Public URLs and the published HTML file use `miku-xlsx2md`, while internal identifiers, script names, and specification document names may continue to use `xlsx2md`.
@@ -178,7 +180,7 @@ For more details, see:
 
 ## Example
 
-This is the main `Mikuku's xlsx2md` screen where you load an Excel workbook and review the generated result.
+This is the main `miku-xlsx2md` screen where you load an Excel workbook and review the generated result.
 
 ![xlsx2md screenshot 0](docs/screenshots/xlsx2md_0.png)
 
@@ -186,7 +188,7 @@ The input workbook can contain prose, tables, images, and other spreadsheet cont
 
 ![xlsx2md screenshot 1](docs/screenshots/xlsx2md_1.png)
 
-After loading the workbook, `Mikuku's xlsx2md` extracts the content and generates Markdown text automatically.
+After loading the workbook, `miku-xlsx2md` extracts the content and generates Markdown text automatically.
 
 ![xlsx2md screenshot 2a](docs/screenshots/xlsx2md_2a.png)
 
@@ -196,7 +198,7 @@ The generated Markdown can then be previewed as a readable document.
 
 ## License
 
-### Mikuku's xlsx2md
+### miku-xlsx2md
 
 - Released under the Apache License 2.0
 - See [LICENSE](./LICENSE) for the full license text
@@ -206,7 +208,9 @@ The generated Markdown can then be previewed as a readable document.
 
 ## What is this?
 
-`Mikuku's xlsx2md` は、Excel (`.xlsx`) をローカルで読み込み、地の文・表・画像を Markdown として抽出する Single-file Web App です。
+`miku-xlsx2md` は Mikuku's software series を構成するツールのひとつです。
+
+`miku-xlsx2md` は、Excel (`.xlsx`) をローカルで読み込み、地の文・表・画像を Markdown として抽出する Single-file Web App です。
 
 - ブラウザ内でローカルに動作し、サーバ通信を行いません
 - Excel ブック全体を、シートごとの手作業なしで自動変換します
@@ -230,9 +234,9 @@ The generated Markdown can then be previewed as a readable document.
 
 ## 主な機能の対応状況
 
-`Mikuku's xlsx2md` は、Excel の見た目をそのまま再現することよりも、ブック内の情報を意味のある Markdown として取り出すことを重視しています。代表的な観点での対応状況は次のとおりです。
+`miku-xlsx2md` は、Excel の見た目をそのまま再現することよりも、ブック内の情報を意味のある Markdown として取り出すことを重視しています。代表的な観点での対応状況は次のとおりです。
 
-| 項目 | `Mikuku's xlsx2md` の状況 | 補足 |
+| 項目 | `miku-xlsx2md` の状況 | 補足 |
 | --- | --- | --- |
 | `.xlsx` を読み込める | 対応 | ブラウザ内でローカル実行できる |
 | ブック全体を一括変換できる | 対応 | 全シートをまとめて処理できる |
@@ -365,7 +369,7 @@ npm run cli -- ./tests/fixtures/xlsx2md-basic-sample01.xlsx --out /tmp/xlsx2md-s
 - リポジトリ名: `miku-xlsx2md`
 - 公開する Single-file App: `miku-xlsx2md.html`
 - プロダクト名 / 内部名: `xlsx2md`
-- 表示名: `Mikuku's xlsx2md`
+- 表示名: `miku-xlsx2md`
 
 このリポジトリは `xlsx2md` から `miku-xlsx2md` へ移設しました。
 公開 URL や公開 HTML 名は `miku-xlsx2md` を使いますが、内部識別子、スクリプト名、仕様書名には `xlsx2md` が残ることがあります。
@@ -389,7 +393,7 @@ npm run cli -- ./tests/fixtures/xlsx2md-basic-sample01.xlsx --out /tmp/xlsx2md-s
 
 ## Example
 
-これは `Mikuku's xlsx2md` のメイン画面です。ここで Excel ブックを読み込み、生成された結果を確認します。
+これは `miku-xlsx2md` のメイン画面です。ここで Excel ブックを読み込み、生成された結果を確認します。
 
 ![xlsx2md screenshot 0](docs/screenshots/xlsx2md_0.png)
 
@@ -397,7 +401,7 @@ npm run cli -- ./tests/fixtures/xlsx2md-basic-sample01.xlsx --out /tmp/xlsx2md-s
 
 ![xlsx2md screenshot 1](docs/screenshots/xlsx2md_1.png)
 
-ブックを読み込むと、`Mikuku's xlsx2md` が内容を抽出し、Markdown テキストを自動生成します。
+ブックを読み込むと、`miku-xlsx2md` が内容を抽出し、Markdown テキストを自動生成します。
 
 ![xlsx2md screenshot 2a](docs/screenshots/xlsx2md_2a.png)
 
@@ -407,7 +411,7 @@ npm run cli -- ./tests/fixtures/xlsx2md-basic-sample01.xlsx --out /tmp/xlsx2md-s
 
 ## License
 
-### Mikuku's xlsx2md
+### miku-xlsx2md
 
 - Apache License 2.0 のもとで公開しています
 - ライセンス本文は [LICENSE](./LICENSE) を参照してください

--- a/TODO.md
+++ b/TODO.md
@@ -46,18 +46,19 @@
 
 - [ ] README に新リポジトリ URL / 公開 URL を明記する
   - 現状:
-    - README 自体は表示名 `Mikuku's xlsx2md` で概ね統一済み
-    - ただし新しい GitHub URL や Pages URL の明示導線が弱い
+    - README の表示名は `miku-xlsx2md` に統一済み
+    - 新しい GitHub URL や Pages URL の導線も概ね更新済み
   - 方針候補:
     - 冒頭付近に公開先 URL を追加
     - `Use` セクションまたは `What is this?` 付近にリポジトリ URL を追加
 
 - [ ] `package.json` / `package-lock.json` の package 名をどうするか決める
   - 現状:
-    - `name` は `local-html-tools`
+    - `package.json` の `name` は `miku-xlsx2md` に更新済み
+    - `package-lock.json` 側も必要なら追随させる
   - 判断ポイント:
     - 非公開のローカル用メタデータとして維持するなら変更不要
-    - `miku-xlsx2md` リポジトリの package として揃えるなら rename 候補
+    - `miku-xlsx2md` リポジトリの package として揃えるなら `package-lock.json` も更新する
   - 対象:
     - `package.json`
     - `package-lock.json`
@@ -124,13 +125,13 @@
   - 旧プロジェクト名見出し
 
 - `package.json`
-  - package 名が `local-html-tools`
+  - package 名は `miku-xlsx2md` に更新済み
 
 - `package-lock.json`
   - package 名が `local-html-tools`
 
 ## 補足
 
-- `README.md` は表示名としてはかなり整理済みで、大きく壊れてはいない
-- 問題の中心は「旧 URL が残っていること」と「リポジトリ名変更後の表記ルールがまだ未確定なこと」
-- 次の実作業としては、まず URL と `CONTRIBUTING.md` を直し、その後 package 名や公開ファイル名の方針を決めるのが安全
+- `README.md` の表示名、公開 HTML 名、命名方針は更新済み
+- 旧 URL は移行メモとして `TODO.md` にだけ残している
+- 外向けの整理は一通り完了しており、残課題は内部名をどこまで維持するかの運用判断が中心

--- a/index-src.html
+++ b/index-src.html
@@ -6,16 +6,16 @@
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0" />
   <meta http-equiv="Pragma" content="no-cache" />
   <meta http-equiv="Expires" content="0" />
-  <title>Mikuku's xlsx2md</title>
-  <meta name="description" content="Mikuku's xlsx2md is a local browser tool that reads Excel (.xlsx) workbooks and converts prose, tables, and images into Markdown." />
-  <meta property="og:title" content="Mikuku's xlsx2md" />
+  <title>miku-xlsx2md</title>
+  <meta name="description" content="miku-xlsx2md is a local browser tool that reads Excel (.xlsx) workbooks and converts prose, tables, and images into Markdown." />
+  <meta property="og:title" content="miku-xlsx2md" />
   <meta property="og:description" content="Read Excel (.xlsx) locally in the browser and convert prose, tables, and images into Markdown." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://igapyon.github.io/miku-xlsx2md/" />
   <meta property="og:image" content="https://igapyon.github.io/miku-xlsx2md/docs/screenshots/xlsx2md-ogp.png" />
-  <meta property="og:image:alt" content="Mikuku's xlsx2md OGP image" />
+  <meta property="og:image:alt" content="miku-xlsx2md OGP image" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Mikuku's xlsx2md" />
+  <meta name="twitter:title" content="miku-xlsx2md" />
   <meta name="twitter:description" content="Read Excel (.xlsx) locally in the browser and convert prose, tables, and images into Markdown." />
   <meta name="twitter:image" content="https://igapyon.github.io/miku-xlsx2md/docs/screenshots/xlsx2md-ogp.png" />
   <style>
@@ -206,13 +206,13 @@
 <body>
   <main class="card">
     <div class="eyebrow">Local Browser Tool</div>
-    <h1>Mikuku's xlsx2md</h1>
+    <h1>miku-xlsx2md</h1>
     <div class="md-app-meta">Updated: {{BUILD_DATE}}</div>
 
     <section class="lang-block" aria-label="English What is this">
       <h2>What is this?</h2>
       <p>
-        <code>Mikuku's xlsx2md</code> is a single-file web app that reads Excel (<code>.xlsx</code>) files locally and extracts prose, tables, and images as Markdown.
+        <code>miku-xlsx2md</code> is a single-file web app that reads Excel (<code>.xlsx</code>) files locally and extracts prose, tables, and images as Markdown.
       </p>
       <ul>
         <li>Runs entirely in the browser with no server communication.</li>
@@ -261,7 +261,7 @@
         <li>Save the result as Markdown or ZIP.</li>
       </ol>
       <div class="link-row">
-        <a class="link-btn" href="./miku-xlsx2md.html?v=202603190000">Open Mikuku's xlsx2md</a>
+        <a class="link-btn" href="./miku-xlsx2md.html?v=202603190000">Open miku-xlsx2md</a>
         <a class="link-btn-secondary" href="https://github.com/igapyon/miku-xlsx2md" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
     </section>
@@ -289,10 +289,10 @@
       <h2>Example</h2>
       <div class="gallery">
         <figure class="shot-card">
-          <img src="./docs/screenshots/xlsx2md_0.png" alt="Mikuku's xlsx2md application screenshot" loading="lazy" />
+          <img src="./docs/screenshots/xlsx2md_0.png" alt="miku-xlsx2md application screenshot" loading="lazy" />
           <figcaption>
-            English: This is the main <code>Mikuku's xlsx2md</code> screen where you load an Excel workbook and review the generated result.<br />
-            日本語: これは <code>Mikuku's xlsx2md</code> のメイン画面です。ここで Excel ブックを読み込み、生成された結果を確認します。
+            English: This is the main <code>miku-xlsx2md</code> screen where you load an Excel workbook and review the generated result.<br />
+            日本語: これは <code>miku-xlsx2md</code> のメイン画面です。ここで Excel ブックを読み込み、生成された結果を確認します。
           </figcaption>
         </figure>
         <figure class="shot-card">
@@ -305,8 +305,8 @@
         <figure class="shot-card">
           <img src="./docs/screenshots/xlsx2md_2a.png" alt="Converted Markdown text screenshot" loading="lazy" />
           <figcaption>
-            English: After loading the workbook, <code>Mikuku's xlsx2md</code> extracts the content and generates Markdown text automatically.<br />
-            日本語: ブックを読み込むと、<code>Mikuku's xlsx2md</code> が内容を抽出し、Markdown テキストを自動生成します。
+            English: After loading the workbook, <code>miku-xlsx2md</code> extracts the content and generates Markdown text automatically.<br />
+            日本語: ブックを読み込むと、<code>miku-xlsx2md</code> が内容を抽出し、Markdown テキストを自動生成します。
           </figcaption>
         </figure>
         <figure class="shot-card">
@@ -324,7 +324,7 @@
     <section class="lang-block" aria-label="Japanese What is this">
       <h2>What is this?</h2>
       <p>
-        <code>Mikuku's xlsx2md</code> は、Excel (<code>.xlsx</code>) をローカルで読み込み、地の文・表・画像を Markdown として抽出する Single-file Web App です。
+        <code>miku-xlsx2md</code> は、Excel (<code>.xlsx</code>) をローカルで読み込み、地の文・表・画像を Markdown として抽出する Single-file Web App です。
       </p>
       <ul>
         <li>ブラウザ内でローカルに動作し、サーバ通信を行いません。</li>
@@ -373,7 +373,7 @@
         <li>Markdown または ZIP を保存します。</li>
       </ol>
       <div class="link-row">
-        <a class="link-btn" href="./miku-xlsx2md.html?v=202603190000">Mikuku's xlsx2md を開く</a>
+        <a class="link-btn" href="./miku-xlsx2md.html?v=202603190000">miku-xlsx2md を開く</a>
         <a class="link-btn-secondary" href="https://github.com/igapyon/miku-xlsx2md" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -6,16 +6,16 @@
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0" />
   <meta http-equiv="Pragma" content="no-cache" />
   <meta http-equiv="Expires" content="0" />
-  <title>Mikuku's xlsx2md</title>
-  <meta name="description" content="Mikuku's xlsx2md is a local browser tool that reads Excel (.xlsx) workbooks and converts prose, tables, and images into Markdown." />
-  <meta property="og:title" content="Mikuku's xlsx2md" />
+  <title>miku-xlsx2md</title>
+  <meta name="description" content="miku-xlsx2md is a local browser tool that reads Excel (.xlsx) workbooks and converts prose, tables, and images into Markdown." />
+  <meta property="og:title" content="miku-xlsx2md" />
   <meta property="og:description" content="Read Excel (.xlsx) locally in the browser and convert prose, tables, and images into Markdown." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://igapyon.github.io/miku-xlsx2md/" />
   <meta property="og:image" content="https://igapyon.github.io/miku-xlsx2md/docs/screenshots/xlsx2md-ogp.png" />
-  <meta property="og:image:alt" content="Mikuku's xlsx2md OGP image" />
+  <meta property="og:image:alt" content="miku-xlsx2md OGP image" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Mikuku's xlsx2md" />
+  <meta name="twitter:title" content="miku-xlsx2md" />
   <meta name="twitter:description" content="Read Excel (.xlsx) locally in the browser and convert prose, tables, and images into Markdown." />
   <meta name="twitter:image" content="https://igapyon.github.io/miku-xlsx2md/docs/screenshots/xlsx2md-ogp.png" />
   <style>
@@ -206,13 +206,13 @@
 <body>
   <main class="card">
     <div class="eyebrow">Local Browser Tool</div>
-    <h1>Mikuku's xlsx2md</h1>
+    <h1>miku-xlsx2md</h1>
     <div class="md-app-meta">Updated: 2026-04-11</div>
 
     <section class="lang-block" aria-label="English What is this">
       <h2>What is this?</h2>
       <p>
-        <code>Mikuku's xlsx2md</code> is a single-file web app that reads Excel (<code>.xlsx</code>) files locally and extracts prose, tables, and images as Markdown.
+        <code>miku-xlsx2md</code> is a single-file web app that reads Excel (<code>.xlsx</code>) files locally and extracts prose, tables, and images as Markdown.
       </p>
       <ul>
         <li>Runs entirely in the browser with no server communication.</li>
@@ -261,7 +261,7 @@
         <li>Save the result as Markdown or ZIP.</li>
       </ol>
       <div class="link-row">
-        <a class="link-btn" href="./miku-xlsx2md.html?v=202603190000">Open Mikuku's xlsx2md</a>
+        <a class="link-btn" href="./miku-xlsx2md.html?v=202603190000">Open miku-xlsx2md</a>
         <a class="link-btn-secondary" href="https://github.com/igapyon/miku-xlsx2md" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
     </section>
@@ -289,10 +289,10 @@
       <h2>Example</h2>
       <div class="gallery">
         <figure class="shot-card">
-          <img src="./docs/screenshots/xlsx2md_0.png" alt="Mikuku's xlsx2md application screenshot" loading="lazy" />
+          <img src="./docs/screenshots/xlsx2md_0.png" alt="miku-xlsx2md application screenshot" loading="lazy" />
           <figcaption>
-            English: This is the main <code>Mikuku's xlsx2md</code> screen where you load an Excel workbook and review the generated result.<br />
-            日本語: これは <code>Mikuku's xlsx2md</code> のメイン画面です。ここで Excel ブックを読み込み、生成された結果を確認します。
+            English: This is the main <code>miku-xlsx2md</code> screen where you load an Excel workbook and review the generated result.<br />
+            日本語: これは <code>miku-xlsx2md</code> のメイン画面です。ここで Excel ブックを読み込み、生成された結果を確認します。
           </figcaption>
         </figure>
         <figure class="shot-card">
@@ -305,8 +305,8 @@
         <figure class="shot-card">
           <img src="./docs/screenshots/xlsx2md_2a.png" alt="Converted Markdown text screenshot" loading="lazy" />
           <figcaption>
-            English: After loading the workbook, <code>Mikuku's xlsx2md</code> extracts the content and generates Markdown text automatically.<br />
-            日本語: ブックを読み込むと、<code>Mikuku's xlsx2md</code> が内容を抽出し、Markdown テキストを自動生成します。
+            English: After loading the workbook, <code>miku-xlsx2md</code> extracts the content and generates Markdown text automatically.<br />
+            日本語: ブックを読み込むと、<code>miku-xlsx2md</code> が内容を抽出し、Markdown テキストを自動生成します。
           </figcaption>
         </figure>
         <figure class="shot-card">
@@ -324,7 +324,7 @@
     <section class="lang-block" aria-label="Japanese What is this">
       <h2>What is this?</h2>
       <p>
-        <code>Mikuku's xlsx2md</code> は、Excel (<code>.xlsx</code>) をローカルで読み込み、地の文・表・画像を Markdown として抽出する Single-file Web App です。
+        <code>miku-xlsx2md</code> は、Excel (<code>.xlsx</code>) をローカルで読み込み、地の文・表・画像を Markdown として抽出する Single-file Web App です。
       </p>
       <ul>
         <li>ブラウザ内でローカルに動作し、サーバ通信を行いません。</li>
@@ -373,7 +373,7 @@
         <li>Markdown または ZIP を保存します。</li>
       </ol>
       <div class="link-row">
-        <a class="link-btn" href="./miku-xlsx2md.html?v=202603190000">Mikuku's xlsx2md を開く</a>
+        <a class="link-btn" href="./miku-xlsx2md.html?v=202603190000">miku-xlsx2md を開く</a>
         <a class="link-btn-secondary" href="https://github.com/igapyon/miku-xlsx2md" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
     </section>

--- a/miku-xlsx2md-src.html
+++ b/miku-xlsx2md-src.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Mikuku's xlsx2md</title>
+  <title>miku-xlsx2md</title>
   <link rel="stylesheet" href="lht-cmn/css/components.css" />
   <link rel="stylesheet" href="src/css/app.css" />
   <script src="lht-cmn/vendor/material-web-outlined-text-field.bundle.js"></script>
@@ -33,13 +33,13 @@ limitations under the License.
   <main class="md-shell">
     <section class="md-card md-surface-card">
       <lht-page-hero
-        title="Mikuku's xlsx2md"
+        title="miku-xlsx2md"
         subtitle="Analyze an Excel workbook (.xlsx) and convert it to Markdown."
         icon="📘"
-        help-label="About Mikuku's xlsx2md"
+        help-label="About miku-xlsx2md"
         help-wide
         action-href="https://github.com/igapyon/miku-xlsx2md"
-        action-aria-label="Open Mikuku's xlsx2md repository"
+        action-aria-label="Open miku-xlsx2md repository"
         action-icon-id="md-icon-github"
         menu-home-href="./index.html"
         menu-home-label="Back to Home">
@@ -76,7 +76,7 @@ limitations under the License.
                 ]
               </script>
             </lht-select-help>
-            <lht-select-help field-id="tableDetectionModeSelect" label="Table Detection" help-text="Choose how aggressively Mikuku's xlsx2md detects tables. `border` detects tables from bordered regions and reduces borderless fallback detection.">
+            <lht-select-help field-id="tableDetectionModeSelect" label="Table Detection" help-text="Choose how aggressively miku-xlsx2md detects tables. `border` detects tables from bordered regions and reduces borderless fallback detection.">
               <script type="application/json" slot="options">
                 [
                   { "value": "balanced", "label": "balanced: bordered + fallback detection", "selected": true },

--- a/miku-xlsx2md.html
+++ b/miku-xlsx2md.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Mikuku's xlsx2md</title>
+  <title>miku-xlsx2md</title>
   
   
   
@@ -1507,13 +1507,13 @@ lht-preview-output {
   <main class="md-shell">
     <section class="md-card md-surface-card">
       <lht-page-hero
-        title="Mikuku's xlsx2md"
+        title="miku-xlsx2md"
         subtitle="Analyze an Excel workbook (.xlsx) and convert it to Markdown."
         icon="📘"
-        help-label="About Mikuku's xlsx2md"
+        help-label="About miku-xlsx2md"
         help-wide
         action-href="https://github.com/igapyon/miku-xlsx2md"
-        action-aria-label="Open Mikuku's xlsx2md repository"
+        action-aria-label="Open miku-xlsx2md repository"
         action-icon-id="md-icon-github"
         menu-home-href="./index.html"
         menu-home-label="Back to Home">
@@ -1550,7 +1550,7 @@ lht-preview-output {
                 ]
               </script>
             </lht-select-help>
-            <lht-select-help field-id="tableDetectionModeSelect" label="Table Detection" help-text="Choose how aggressively Mikuku's xlsx2md detects tables. `border` detects tables from bordered regions and reduces borderless fallback detection.">
+            <lht-select-help field-id="tableDetectionModeSelect" label="Table Detection" help-text="Choose how aggressively miku-xlsx2md detects tables. `border` detects tables from bordered regions and reduces borderless fallback detection.">
               <script type="application/json" slot="options">
                 [
                   { "value": "balanced", "label": "balanced: bordered + fallback detection", "selected": true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "local-html-tools",
+  "name": "miku-xlsx2md",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "local-html-tools",
+      "name": "miku-xlsx2md",
       "devDependencies": {
         "@material/web": "^2.4.1",
         "@xmldom/xmldom": "^0.9.9",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "local-html-tools",
+  "name": "miku-xlsx2md",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 概要

外向けの表示名を `miku-xlsx2md` に統一し、package メタデータも同じ名前に揃えました。

## 変更内容

- `README.md` のタイトルおよび説明文中の `Mikuku's xlsx2md` を `miku-xlsx2md` に更新
- `README.md` 冒頭に `miku-xlsx2md is one of the tools in Mikuku's software series.` を追記
- `README.md` の命名方針セクションで、表示名を `miku-xlsx2md` に更新
- `index-src.html` と `index.html` のランディングページ文言を更新
  - ページタイトル
  - 説明文
  - OGP / Twitter の title と image alt
  - 見出し、サンプル説明、起動ボタン文言
- `miku-xlsx2md-src.html` と `miku-xlsx2md.html` のアプリ画面文言を更新
  - ページタイトル
  - ヒーロータイトル
  - help label
  - repository action aria-label
  - Table Detection の help text
- `package.json` と `package-lock.json` の package 名を `local-html-tools` から `miku-xlsx2md` に更新
- `TODO.md` の移行メモを現在の状態に合わせて更新

## 影響

- 外向けの表示名が `miku-xlsx2md` で統一されます
- npm 系のコマンド出力に現れる package 名も `miku-xlsx2md` になります
- 内部識別子や仕様書名などの `xlsx2md` はそのまま維持します

## 対象ファイル

- `README.md`
- `TODO.md`
- `index-src.html`
- `index.html`
- `miku-xlsx2md-src.html`
- `miku-xlsx2md.html`
- `package.json`
- `package-lock.json`