### PR TITLE
`planner-aware` テーブル検知モード追加と GUI/CLI 既定値・ヘルプ整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Links:
 
 ## Current Status
 
-- `display / raw / both`, `plain / github`, and `balanced / border` are implemented in both the browser UI and the Node.js CLI
+- `display / raw / both`, `plain / github`, and `balanced / border / planner-aware` are implemented in both the browser UI and the Node.js CLI
 - Output `encoding` / `bom` switching is implemented for Markdown export and ZIP export
 - Layout-heavy sheets are handled with lightweight section grouping, but calendar / board / dashboard style sheets still have room for improvement
 - Markdown escaping, formula coverage, and layout interpretation continue to be refined incrementally
@@ -86,6 +86,7 @@ Default save names are `workbook.md` for Markdown and `workbook.zip` for ZIP, ba
 You can also run the conversion in batch mode from Node.js.
 The CLI intentionally stays small in the Unix style: one input workbook at a time, with Markdown or ZIP written to a file.
 CLI interface may change.
+Defaults are aligned with the browser GUI: `display`, `github`, `balanced`, and shape details `exclude`.
 
 Options:
 
@@ -93,7 +94,7 @@ Options:
 - `--zip <file>`: Write ZIP export to a file
 - `--output-mode <mode>`: `display`, `raw`, or `both`
 - `--formatting-mode <mode>`: `plain` or `github`
-- `--table-detection-mode <mode>`: `balanced` or `border`
+- `--table-detection-mode <mode>`: `balanced`, `border`, or `planner-aware`
 - `--encoding <value>`: `utf-8`, `shift_jis`, `utf-16le`, `utf-16be`, `utf-32le`, or `utf-32be`
 - `--bom <value>`: `off` or `on`
 - `--shape-details <mode>`: `include` or `exclude`
@@ -134,7 +135,7 @@ You can also switch how Excel text emphasis is rendered. `github` formatting mod
 npm run cli -- ./tests/fixtures/rich/rich-text-github-sample01.xlsx --formatting-mode github
 ```
 
-You can also switch table detection behavior. `balanced` keeps the existing heuristic, while `border` detects tables from bordered regions and suppresses borderless fallback detection.
+You can also switch table detection behavior. `balanced` keeps the generic heuristic, `border` detects tables from bordered regions and suppresses borderless fallback detection, and `planner-aware` adds planner/calendar-specific suppression heuristics for layout-heavy sheets.
 
 ```bash
 npm run cli -- ./tests/fixtures/table/table-border-priority-sample01.xlsx --table-detection-mode border
@@ -295,6 +296,7 @@ The generated Markdown can then be previewed as a readable document.
 Node.js からバッチ実行することもできます。
 CLI は UNIX 的に小さく保つ方針で、基本は 1 回につき 1 つのワークブックを受け取り、Markdown または ZIP をファイルへ出力します。
 CLI interface may change.
+既定値は GUI と揃えてあり、`display` / `github` / `balanced` / shape details `exclude` です。
 
 オプション一覧:
 
@@ -302,7 +304,7 @@ CLI interface may change.
 - `--zip <file>`: ZIP をファイルへ出力
 - `--output-mode <mode>`: `display` / `raw` / `both`
 - `--formatting-mode <mode>`: `plain` / `github`
-- `--table-detection-mode <mode>`: `balanced` / `border`
+- `--table-detection-mode <mode>`: `balanced` / `border` / `planner-aware`
 - `--encoding <value>`: `utf-8` / `shift_jis` / `utf-16le` / `utf-16be` / `utf-32le` / `utf-32be`
 - `--bom <value>`: `off` / `on`
 - `--shape-details <mode>`: `include` / `exclude`
@@ -343,7 +345,7 @@ Excel の文字装飾の出し方も切り替えられます。`github` formatti
 npm run cli -- ./tests/fixtures/rich/rich-text-github-sample01.xlsx --formatting-mode github
 ```
 
-表検出の挙動も切り替えられます。`balanced` は既定のヒューリスティックを維持し、`border` は罫線のある領域からだけ表を検出し、borderless fallback 検知を抑えます。
+表検出の挙動も切り替えられます。`balanced` は汎用ヒューリスティックを維持し、`border` は罫線のある領域からだけ表を検出し、`planner-aware` は planner / calendar 系のレイアウト向け抑制ヒューリスティックを追加します。
 
 ```bash
 npm run cli -- ./tests/fixtures/table/table-border-priority-sample01.xlsx --table-detection-mode border

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
   <main class="card">
     <div class="eyebrow">Local Browser Tool</div>
     <h1>miku-xlsx2md</h1>
-    <div class="md-app-meta">Updated: 2026-04-21</div>
+    <div class="md-app-meta">Updated: 2026-04-23</div>
 
     <section class="lang-block" aria-label="English What is this">
       <h2>What is this?</h2>

--- a/miku-xlsx2md-src.html
+++ b/miku-xlsx2md-src.html
@@ -76,11 +76,12 @@ limitations under the License.
                 ]
               </script>
             </lht-select-help>
-            <lht-select-help field-id="tableDetectionModeSelect" label="Table Detection" help-text="Choose how aggressively miku-xlsx2md detects tables. `border` detects tables from bordered regions and reduces borderless fallback detection.">
+            <lht-select-help field-id="tableDetectionModeSelect" label="Table Detection" help-text="Choose how aggressively miku-xlsx2md detects tables. `border` trusts bordered regions, while `planner-aware` adds planner/calendar-specific suppression heuristics.">
               <script type="application/json" slot="options">
                 [
                   { "value": "balanced", "label": "balanced: bordered + fallback detection", "selected": true },
-                  { "value": "border", "label": "border: bordered regions only" }
+                  { "value": "border", "label": "border: bordered regions only" },
+                  { "value": "planner-aware", "label": "planner-aware: layout-heavy planner heuristics" }
                 ]
               </script>
             </lht-select-help>
@@ -125,7 +126,7 @@ limitations under the License.
             <lht-switch-help switch-id="removeEmptyColumnsEnabled" label="Remove empty columns" help-label="About empty-column removal" checked>
               Remove empty columns from detected tables where possible.
             </lht-switch-help>
-            <lht-switch-help switch-id="includeShapeDetailsEnabled" label="Include shape details in Markdown" help-label="About shape details" checked>
+            <lht-switch-help switch-id="includeShapeDetailsEnabled" label="Include shape details in Markdown" help-label="About shape details">
               Include Shape Blocks and Shapes sections in the generated Markdown output.
             </lht-switch-help>
           </div>
@@ -211,6 +212,7 @@ limitations under the License.
   <script src="src/js/markdown-escape.js"></script>
   <script src="src/js/markdown-table-escape.js"></script>
   <script src="src/js/text-encoding.js"></script>
+  <script src="src/js/markdown-options.js"></script>
   <script src="src/js/rich-text-parser.js"></script>
   <script src="src/js/rich-text-plain-formatter.js"></script>
   <script src="src/js/rich-text-github-formatter.js"></script>

--- a/miku-xlsx2md.html
+++ b/miku-xlsx2md.html
@@ -1550,11 +1550,12 @@ lht-preview-output {
                 ]
               </script>
             </lht-select-help>
-            <lht-select-help field-id="tableDetectionModeSelect" label="Table Detection" help-text="Choose how aggressively miku-xlsx2md detects tables. `border` detects tables from bordered regions and reduces borderless fallback detection.">
+            <lht-select-help field-id="tableDetectionModeSelect" label="Table Detection" help-text="Choose how aggressively miku-xlsx2md detects tables. `border` trusts bordered regions, while `planner-aware` adds planner/calendar-specific suppression heuristics.">
               <script type="application/json" slot="options">
                 [
                   { "value": "balanced", "label": "balanced: bordered + fallback detection", "selected": true },
-                  { "value": "border", "label": "border: bordered regions only" }
+                  { "value": "border", "label": "border: bordered regions only" },
+                  { "value": "planner-aware", "label": "planner-aware: layout-heavy planner heuristics" }
                 ]
               </script>
             </lht-select-help>
@@ -1599,7 +1600,7 @@ lht-preview-output {
             <lht-switch-help switch-id="removeEmptyColumnsEnabled" label="Remove empty columns" help-label="About empty-column removal" checked>
               Remove empty columns from detected tables where possible.
             </lht-switch-help>
-            <lht-switch-help switch-id="includeShapeDetailsEnabled" label="Include shape details in Markdown" help-label="About shape details" checked>
+            <lht-switch-help switch-id="includeShapeDetailsEnabled" label="Include shape details in Markdown" help-label="About shape details">
               Include Shape Blocks and Shapes sections in the generated Markdown output.
             </lht-switch-help>
           </div>
@@ -1675,6 +1676,7 @@ lht-preview-output {
     </section>
   </main>
 
+  
   
   
   
@@ -4804,6 +4806,66 @@ if (!customElements.get("lht-page-menu")) {
  */
 (() => {
     const moduleRegistry = getXlsx2mdModuleRegistry();
+    const OUTPUT_MODES = ["display", "raw", "both"];
+    const FORMATTING_MODES = ["plain", "github"];
+    const TABLE_DETECTION_MODES = ["balanced", "border", "planner-aware"];
+    const TABLE_DETECTION_MODE_ALIASES = {
+        "border-priority": "border"
+    };
+    function normalizeEnum(value, allowedValues, fallback, aliases = {}) {
+        const normalizedInput = String(value || "").trim().toLowerCase();
+        if (!normalizedInput) {
+            return fallback;
+        }
+        const normalizedValue = aliases[normalizedInput] || normalizedInput;
+        return allowedValues.includes(normalizedValue)
+            ? normalizedValue
+            : fallback;
+    }
+    function resolveBoolean(value, fallback) {
+        return value === undefined || value === null ? fallback : value !== false;
+    }
+    function normalizeOutputMode(value) {
+        return normalizeEnum(value, OUTPUT_MODES, "display");
+    }
+    function normalizeFormattingMode(value) {
+        return normalizeEnum(value, FORMATTING_MODES, "plain");
+    }
+    function normalizeTableDetectionMode(value) {
+        return normalizeEnum(value, TABLE_DETECTION_MODES, "balanced", TABLE_DETECTION_MODE_ALIASES);
+    }
+    function resolveMarkdownOptions(options = {}) {
+        return {
+            treatFirstRowAsHeader: resolveBoolean(options.treatFirstRowAsHeader, true),
+            trimText: resolveBoolean(options.trimText, true),
+            removeEmptyRows: resolveBoolean(options.removeEmptyRows, true),
+            removeEmptyColumns: resolveBoolean(options.removeEmptyColumns, true),
+            includeShapeDetails: resolveBoolean(options.includeShapeDetails, true),
+            outputMode: normalizeOutputMode(options.outputMode),
+            formattingMode: normalizeFormattingMode(options.formattingMode),
+            tableDetectionMode: normalizeTableDetectionMode(options.tableDetectionMode)
+        };
+    }
+    moduleRegistry.registerModule("markdownOptions", {
+        OUTPUT_MODES,
+        FORMATTING_MODES,
+        TABLE_DETECTION_MODES,
+        TABLE_DETECTION_MODE_ALIASES,
+        normalizeOutputMode,
+        normalizeFormattingMode,
+        normalizeTableDetectionMode,
+        resolveMarkdownOptions
+    });
+})();
+  </script>
+
+  <script>
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+(() => {
+    const moduleRegistry = getXlsx2mdModuleRegistry();
     function createRichTextParserApi(deps = {}) {
         const markdownEscapeHelper = requireXlsx2mdMarkdownEscape();
         const normalizeInlineText = deps.normalizeMarkdownText || ((text) => String(text || "").replace(/\r\n?|\n/g, " ").replace(/\t/g, " "));
@@ -5090,9 +5152,62 @@ if (!customElements.get("lht-page-menu")) {
     function isIndentedChildItem(parent, child) {
         return !!(parent && child && child.startCol > parent.startCol);
     }
+    function isWeekdayToken(value) {
+        const normalized = String(value || "").trim();
+        return ["日", "月", "火", "水", "木", "金", "土", "日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"].includes(normalized);
+    }
+    function isIsoDateToken(value) {
+        return /^\d{4}-\d{2}-\d{2}$/.test(String(value || "").trim());
+    }
+    function isCalendarLikeItem(item) {
+        if (!item || !Array.isArray(item.cellValues)) {
+            return false;
+        }
+        const values = item.cellValues.map((value) => String(value || "").trim()).filter(Boolean);
+        if (values.length < 5) {
+            return false;
+        }
+        const weekdayCount = values.filter(isWeekdayToken).length;
+        const dateCount = values.filter(isIsoDateToken).length;
+        return weekdayCount >= 5 || dateCount >= 5 || values.length >= 7;
+    }
+    function isCalendarLikeNarrativeBlock(block) {
+        if (!block.items || block.items.length < 2) {
+            return false;
+        }
+        const calendarLikeItems = block.items.filter((item) => isCalendarLikeItem(item));
+        return calendarLikeItems.length >= 2;
+    }
+    function renderCalendarLikeItem(item) {
+        const values = item.cellValues.map((value) => String(value || "").trim()).filter(Boolean);
+        if (values.length === 0) {
+            return normalizeNarrativeText(item.text);
+        }
+        if (values.every(isWeekdayToken)) {
+            return formatNarrativeHeading(values.join(" "));
+        }
+        if (values.every((value) => isIsoDateToken(value) || isWeekdayToken(value))) {
+            return values.join(" | ");
+        }
+        return values.join(" | ");
+    }
+    function renderCalendarLikeNarrativeBlock(block) {
+        return block.items
+            .map((item) => {
+            const values = item.cellValues.map((value) => String(value || "").trim()).filter(Boolean);
+            if (isCalendarLikeItem(item) || values.length >= 2) {
+                return renderCalendarLikeItem(item);
+            }
+            return normalizeNarrativeText(item.text);
+        })
+            .join("\n\n");
+    }
     function renderNarrativeBlock(block) {
         if (!block.items || block.items.length === 0) {
             return block.lines.map((line) => normalizeNarrativeText(line)).join("\n");
+        }
+        if (isCalendarLikeNarrativeBlock(block)) {
+            return renderCalendarLikeNarrativeBlock(block);
         }
         const parts = [];
         let index = 0;
@@ -5127,7 +5242,8 @@ if (!customElements.get("lht-page-menu")) {
     }
     const narrativeStructureApi = {
         renderNarrativeBlock,
-        isSectionHeadingNarrativeBlock
+        isSectionHeadingNarrativeBlock,
+        isCalendarLikeNarrativeBlock
     };
     moduleRegistry.registerModule("narrativeStructure", narrativeStructureApi);
 })();
@@ -5250,12 +5366,70 @@ if (!customElements.get("lht-page-menu")) {
             return true;
         });
     }
+    function pruneCalendarLikeColumnCandidates(candidates) {
+        const dropKeys = new Set();
+        const sorted = [...candidates].sort((left, right) => {
+            if (left.startRow !== right.startRow)
+                return left.startRow - right.startRow;
+            if (left.endRow !== right.endRow)
+                return left.endRow - right.endRow;
+            return left.startCol - right.startCol;
+        });
+        let cluster = [];
+        function flushCluster() {
+            if (cluster.length < 3) {
+                cluster = [];
+                return;
+            }
+            for (const candidate of cluster) {
+                dropKeys.add(`${candidate.startRow}:${candidate.startCol}:${candidate.endRow}:${candidate.endCol}`);
+            }
+            cluster = [];
+        }
+        function isCalendarLikeColumn(candidate) {
+            const rowCount = candidate.endRow - candidate.startRow + 1;
+            const colCount = candidate.endCol - candidate.startCol + 1;
+            return rowCount >= 4 && colCount <= 3;
+        }
+        for (const candidate of sorted) {
+            if (!isCalendarLikeColumn(candidate)) {
+                flushCluster();
+                continue;
+            }
+            const previous = cluster[cluster.length - 1];
+            if (!previous) {
+                cluster.push(candidate);
+                continue;
+            }
+            const sameBand = candidate.startRow === previous.startRow && candidate.endRow === previous.endRow;
+            const horizontalGap = candidate.startCol - previous.endCol;
+            if (sameBand && horizontalGap >= 1 && horizontalGap <= 2) {
+                cluster.push(candidate);
+            }
+            else {
+                flushCluster();
+                cluster.push(candidate);
+            }
+        }
+        flushCluster();
+        return candidates.filter((candidate) => !dropKeys.has(`${candidate.startRow}:${candidate.startCol}:${candidate.endRow}:${candidate.endCol}`));
+    }
     function detectTableCandidates(sheet, buildCellMap, scoreWeights = DEFAULT_TABLE_SCORE_WEIGHTS, tableDetectionMode = "balanced") {
         const cellMap = buildCellMap(sheet);
         const allSeedCells = collectTableSeedCells(sheet);
         const borderSeedCells = collectBorderSeedCells(sheet);
         const candidates = [];
         const candidateKeys = new Set();
+        function countSparseRows(component, startRow, endRow) {
+            let sparseRows = 0;
+            for (let row = startRow; row <= endRow; row += 1) {
+                const nonEmptyCount = component.filter((entry) => entry.row === row && entry.outputValue.trim()).length;
+                if (nonEmptyCount <= 2) {
+                    sparseRows += 1;
+                }
+            }
+            return sparseRows;
+        }
         function maybePushCandidate(component, sourceKind = "border") {
             const rows = component.map((entry) => entry.row);
             const cols = component.map((entry) => entry.col);
@@ -5267,6 +5441,8 @@ if (!customElements.get("lht-page-menu")) {
             const density = component.filter((entry) => entry.outputValue.trim()).length / area;
             const rowCount = endRow - startRow + 1;
             const colCount = endCol - startCol + 1;
+            const sparseRowCount = countSparseRows(component, startRow, endRow);
+            const nonEmptyCells = component.filter((entry) => entry.outputValue.trim());
             if (rowCount < 2 || colCount < 2) {
                 return;
             }
@@ -5305,15 +5481,45 @@ if (!customElements.get("lht-page-menu")) {
                 score += scoreWeights.mergeHeavyPenalty;
                 reasons.push(`Many merged cells (${scoreWeights.mergeHeavyPenalty})`);
             }
+            const plannerAwareMode = tableDetectionMode === "planner-aware";
             if (sourceKind === "border") {
+                const looksLikeTinyMergedLabelStub = (rowCount <= 2
+                    && colCount <= 2
+                    && mergedArea >= 1
+                    && nonEmptyCells.length <= 2
+                    && headerishCount <= 1);
+                if (looksLikeTinyMergedLabelStub) {
+                    return;
+                }
                 if (mergedArea >= 2 && density < 0.25 && headerishCount < 2) {
                     return;
                 }
+                if (plannerAwareMode) {
+                    const looksLikeWideSparseMergeForm = (colCount >= 8
+                        && rowCount >= 4
+                        && density < 0.45
+                        && mergedArea >= Math.max(4, rowCount - 1)
+                        && sparseRowCount >= Math.ceil(rowCount * 0.7));
+                    if (looksLikeWideSparseMergeForm) {
+                        return;
+                    }
+                }
             }
-            else if (mergedArea >= 2 && rowCount <= 6 && colCount >= 10 && density < 0.25) {
-                return;
+            else {
+                if (mergedArea >= 2 && rowCount <= 6 && colCount >= 10 && density < 0.25) {
+                    return;
+                }
+                if (plannerAwareMode) {
+                    const looksLikeMixedLayoutSheet = (rowCount >= 20
+                        && colCount >= 8
+                        && mergedArea >= 4
+                        && sparseRowCount >= 4
+                        && density < 0.8);
+                    if (looksLikeMixedLayoutSheet) {
+                        return;
+                    }
+                }
             }
-            const nonEmptyCells = component.filter((entry) => entry.outputValue.trim());
             const avgTextLength = nonEmptyCells
                 .reduce((sum, entry) => sum + entry.outputValue.trim().length, 0) / Math.max(1, nonEmptyCells.length);
             if (avgTextLength > 36 && density < 0.7) {
@@ -5327,6 +5533,10 @@ if (!customElements.get("lht-page-menu")) {
                     endRow,
                     endCol
                 });
+                if (normalizedBounds.endRow - normalizedBounds.startRow + 1 < 2
+                    || normalizedBounds.endCol - normalizedBounds.startCol + 1 < 2) {
+                    return;
+                }
                 const key = `${normalizedBounds.startRow}:${normalizedBounds.startCol}:${normalizedBounds.endRow}:${normalizedBounds.endCol}`;
                 if (candidateKeys.has(key)) {
                     return;
@@ -5366,7 +5576,11 @@ if (!customElements.get("lht-page-menu")) {
                 maybePushCandidate(component, "fallback");
             }
         }
-        return pruneRedundantCandidates(candidates).sort((left, right) => {
+        const prunedCandidates = pruneRedundantCandidates(candidates);
+        const finalCandidates = tableDetectionMode === "planner-aware"
+            ? pruneCalendarLikeColumnCandidates(prunedCandidates)
+            : prunedCandidates;
+        return finalCandidates.sort((left, right) => {
             if (left.startRow !== right.startRow)
                 return left.startRow - right.startRow;
             return left.startCol - right.startCol;
@@ -5448,7 +5662,7 @@ if (!customElements.get("lht-page-menu")) {
         const text = String(value || "").trim();
         if (!text)
             return false;
-        return text !== "[MERGED←]" && text !== "[MERGED↑]";
+        return text !== "[←M←]" && text !== "[↑M↑]";
     }
     function applyMergeTokens(matrix, merges, startRow, startCol, endRow, endCol) {
         for (const merge of merges) {
@@ -5464,7 +5678,7 @@ if (!customElements.get("lht-page-menu")) {
                     if (!matrix[matrixRow] || typeof matrix[matrixRow][matrixCol] === "undefined") {
                         continue;
                     }
-                    matrix[matrixRow][matrixCol] = row === merge.startRow ? "[MERGED←]" : "[MERGED↑]";
+                    matrix[matrixRow][matrixCol] = row === merge.startRow ? "[←M←]" : "[↑M↑]";
                 }
             }
         }
@@ -5473,6 +5687,7 @@ if (!customElements.get("lht-page-menu")) {
         collectTableSeedCells,
         collectBorderSeedCells,
         pruneRedundantCandidates,
+        pruneCalendarLikeColumnCandidates,
         detectTableCandidates,
         trimTableCandidateBounds,
         matrixFromCandidate,
@@ -5877,6 +6092,34 @@ if (!customElements.get("lht-page-menu")) {
         function shouldStartNarrativeBlock(current, rowNumber, previousRow, startCol) {
             return !current || rowNumber - previousRow > 1 || Math.abs(startCol - current.startCol) > 3;
         }
+        function isIsoDateToken(value) {
+            return /^\d{4}-\d{2}-\d{2}$/.test(String(value || "").trim());
+        }
+        function isWeekdayToken(value) {
+            const normalized = String(value || "").trim();
+            return ["日", "月", "火", "水", "木", "金", "土", "日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"].includes(normalized);
+        }
+        function isCalendarDateItem(item) {
+            if (!item)
+                return false;
+            const values = (item.cellValues || []).map((value) => String(value || "").trim()).filter(Boolean);
+            return values.length >= 5 && values.every((value) => isIsoDateToken(value) || isWeekdayToken(value));
+        }
+        function blockHasCalendarDateItem(block) {
+            var _a;
+            return !!((_a = block === null || block === void 0 ? void 0 : block.items) === null || _a === void 0 ? void 0 : _a.some((item) => isCalendarDateItem(item)));
+        }
+        function shouldAppendToCalendarNarrativeBlock(current, item, previousRow) {
+            if (!current || !blockHasCalendarDateItem(current)) {
+                return false;
+            }
+            const rowGap = item.row - previousRow;
+            if (rowGap < 0 || rowGap > 4) {
+                return false;
+            }
+            const startColDelta = Math.abs(item.startCol - current.startCol);
+            return startColDelta <= 24 || isCalendarDateItem(item);
+        }
         function createNarrativeBlockFromItem(item) {
             return {
                 startRow: item.row,
@@ -5897,7 +6140,10 @@ if (!customElements.get("lht-page-menu")) {
             let current = null;
             let previousRow = -100;
             for (const item of items) {
-                if (shouldStartNarrativeBlock(current, item.row, previousRow, item.startCol)) {
+                if (shouldAppendToCalendarNarrativeBlock(current, item, previousRow)) {
+                    appendNarrativeItem(current, item);
+                }
+                else if (shouldStartNarrativeBlock(current, item.row, previousRow, item.startCol)) {
                     current = createNarrativeBlockFromItem(item);
                     blocks.push(current);
                 }
@@ -5913,7 +6159,8 @@ if (!customElements.get("lht-page-menu")) {
                 startRow: block.startRow,
                 startCol: block.startCol,
                 endRow: block.endRow,
-                endCol: Math.max(block.startCol, ...block.items.map((item) => item.startCol))
+                endCol: Math.max(block.startCol, ...block.items.map((item) => item.startCol)),
+                calendarLike: blockHasCalendarDateItem(block)
             }));
         }
         function createTableSectionAnchors(tables) {
@@ -5965,10 +6212,30 @@ if (!customElements.get("lht-page-menu")) {
                 endCol: anchor.endCol
             };
         }
-        function shouldStartNewSectionBlock(current, anchor, previousEndRow) {
+        function shouldStartNewSectionBlock(current, anchor, previousEndRow, previousAnchor) {
             const verticalGapThreshold = 4;
+            const horizontalGapThreshold = 3;
             const gap = anchor.startRow - previousEndRow;
-            return !current || gap > verticalGapThreshold;
+            if (!current) {
+                return true;
+            }
+            if (gap > verticalGapThreshold) {
+                const bothCalendarLike = !!(anchor.calendarLike && (previousAnchor === null || previousAnchor === void 0 ? void 0 : previousAnchor.calendarLike));
+                const horizontalGap = anchor.startCol - current.endCol;
+                if (!(bothCalendarLike && gap <= 8 && horizontalGap <= 24)) {
+                    return true;
+                }
+            }
+            const overlapsCurrentRows = anchor.startRow <= current.endRow + 1;
+            const horizontalGap = anchor.startCol - current.endCol;
+            const bothCalendarLike = !!(anchor.calendarLike && (previousAnchor === null || previousAnchor === void 0 ? void 0 : previousAnchor.calendarLike));
+            if (bothCalendarLike && horizontalGap <= 24 && (overlapsCurrentRows || gap <= 8)) {
+                return false;
+            }
+            if (overlapsCurrentRows && horizontalGap > horizontalGapThreshold) {
+                return true;
+            }
+            return false;
         }
         function extendSectionBlock(section, anchor) {
             section.startRow = Math.min(section.startRow, anchor.startRow);
@@ -5984,8 +6251,9 @@ if (!customElements.get("lht-page-menu")) {
             const sections = [];
             let current = null;
             let previousEndRow = -100;
+            let previousAnchor = null;
             for (const anchor of anchors) {
-                if (shouldStartNewSectionBlock(current, anchor, previousEndRow)) {
+                if (shouldStartNewSectionBlock(current, anchor, previousEndRow, previousAnchor)) {
                     current = createSectionBlockFromAnchor(anchor);
                     sections.push(current);
                 }
@@ -5993,6 +6261,7 @@ if (!customElements.get("lht-page-menu")) {
                     extendSectionBlock(current, anchor);
                 }
                 previousEndRow = Math.max(previousEndRow, anchor.endRow);
+                previousAnchor = anchor;
             }
             return sections;
         }
@@ -6172,7 +6441,80 @@ if (!customElements.get("lht-page-menu")) {
             })).filter((group) => group.entries.length > 0);
         }
         function renderGroupedSectionEntries(entries) {
-            return entries.map((section) => section.markdown.trimEnd()).join("\n\n").trim();
+            return createCalendarAwareSectionEntries(entries).map((section) => section.markdown.trimEnd()).join("\n\n").trim();
+        }
+        function isIsoDateToken(value) {
+            return /^\d{4}-\d{2}-\d{2}$/.test(String(value || "").trim());
+        }
+        function isWeekdayToken(value) {
+            const normalized = String(value || "").trim();
+            return ["日", "月", "火", "水", "木", "金", "土", "日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"].includes(normalized);
+        }
+        function getNarrativeValues(section) {
+            var _a;
+            return ((_a = section.narrativeBlock) === null || _a === void 0 ? void 0 : _a.items.flatMap((item) => item.cellValues || []).map((value) => String(value || "").trim()).filter(Boolean)) || [];
+        }
+        function isCalendarBodySection(section) {
+            if (section.kind !== "narrative" || !section.narrativeBlock)
+                return false;
+            return section.narrativeBlock.items.some((item) => {
+                const values = (item.cellValues || []).map((value) => String(value || "").trim()).filter(Boolean);
+                return values.length >= 5 && values.every((value) => isIsoDateToken(value) || isWeekdayToken(value));
+            });
+        }
+        function isCalendarHeaderSection(section) {
+            if (section.kind !== "narrative" || !section.narrativeBlock)
+                return false;
+            const values = getNarrativeValues(section);
+            if (values.length === 0 || values.length > 10)
+                return false;
+            const allWeekdays = values.length >= 5 && values.every((value) => isWeekdayToken(value));
+            const hasMonthTitle = values.some((value) => /^\d{4}年\d{1,2}月$/.test(value));
+            const hasPlannerLabel = values.includes("目標と優先事項") || values.includes("その他");
+            return allWeekdays || hasMonthTitle || hasPlannerLabel;
+        }
+        function createSyntheticSection(markdown, sortRow, sortCol) {
+            return {
+                sortRow,
+                sortCol,
+                markdown,
+                kind: "narrative"
+            };
+        }
+        function createCalendarAwareSectionEntries(entries) {
+            const mainCalendarEntries = entries.filter((entry) => isCalendarBodySection(entry))
+                .sort((left, right) => {
+                if (left.sortCol !== right.sortCol)
+                    return left.sortCol - right.sortCol;
+                return left.sortRow - right.sortRow;
+            });
+            if (mainCalendarEntries.length === 0) {
+                return entries;
+            }
+            const main = mainCalendarEntries[0];
+            const headerEntries = entries.filter((entry) => (entry !== main
+                && isCalendarHeaderSection(entry)
+                && entry.sortRow <= main.sortRow + 1));
+            const sidebarEntries = entries.filter((entry) => (entry !== main
+                && !headerEntries.includes(entry)
+                && isCalendarBodySection(entry)
+                && entry.sortCol >= main.sortCol + 10));
+            const remainingEntries = entries.filter((entry) => (entry !== main
+                && !headerEntries.includes(entry)
+                && !sidebarEntries.includes(entry)));
+            if (headerEntries.length === 0 && sidebarEntries.length === 0) {
+                return entries;
+            }
+            const reordered = [];
+            reordered.push(...headerEntries);
+            reordered.push(main);
+            if (sidebarEntries.length > 0) {
+                const firstSidebar = sidebarEntries[0];
+                reordered.push(createSyntheticSection("### Sidebar\n", firstSidebar.sortRow - 0.1, firstSidebar.sortCol));
+                reordered.push(...sidebarEntries);
+            }
+            reordered.push(...remainingEntries);
+            return reordered;
         }
         function renderGroupedSectionBody(groupedSections) {
             return groupedSections
@@ -6282,6 +6624,7 @@ if (!customElements.get("lht-page-menu")) {
             extractSectionBlocks,
             sortContentSections,
             createGroupedSections,
+            createCalendarAwareSectionEntries,
             renderGroupedSectionBody,
             collectSheetRenderState,
             createSheetMarkdownText,
@@ -12381,6 +12724,10 @@ if (!customElements.get("lht-page-menu")) {
     }
     function updateTableDetectionModeNotice(mode) {
         const notice = getElement("tableDetectionModeNotice");
+        if (mode === "planner-aware") {
+            notice.textContent = "`planner-aware` adds planner/calendar-specific suppression heuristics for layout-heavy sheets.";
+            return;
+        }
         if (mode === "border") {
             notice.textContent = "`border` detects tables from bordered regions and suppresses borderless fallback detection.";
             return;

--- a/scripts/miku-xlsx2md-cli.mjs
+++ b/scripts/miku-xlsx2md-cli.mjs
@@ -40,8 +40,8 @@ Options:
   --encoding <value>            utf-8 | shift_jis | utf-16le | utf-16be | utf-32le | utf-32be (default: utf-8)
   --bom <value>                 off | on (default: off; shift_jis does not allow on)
   --output-mode <mode>          display | raw | both (default: display)
-  --formatting-mode <mode>      plain | github (default: plain)
-  --table-detection-mode <mode> balanced | border (default: balanced)
+  --formatting-mode <mode>      plain | github (default: github)
+  --table-detection-mode <mode> balanced | border | planner-aware (default: balanced)
   --shape-details <mode>        include | exclude (default: exclude)
   --include-shape-details       Alias for --shape-details include
   --no-header-row               Do not treat the first row as a table header
@@ -50,6 +50,9 @@ Options:
   --keep-empty-columns          Keep empty columns
   --summary                     Print per-sheet summary to stdout
   --help                        Show this help and exit
+
+GUI-aligned defaults:
+  output-mode=display, formatting-mode=github, table-detection-mode=balanced, shape-details=exclude
 
 Exit codes:
   0                             Success
@@ -130,7 +133,7 @@ function parseArgs(argv, markdownOptions) {
     removeEmptyColumns: true,
     includeShapeDetails: false,
     outputMode: "display",
-    formattingMode: "plain",
+    formattingMode: "github",
     tableDetectionMode: "balanced",
     encoding: "utf-8",
     bom: "off",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -252,6 +252,10 @@
     }
     function updateTableDetectionModeNotice(mode) {
         const notice = getElement("tableDetectionModeNotice");
+        if (mode === "planner-aware") {
+            notice.textContent = "`planner-aware` adds planner/calendar-specific suppression heuristics for layout-heavy sheets.";
+            return;
+        }
         if (mode === "border") {
             notice.textContent = "`border` detects tables from bordered regions and suppresses borderless fallback detection.";
             return;

--- a/src/js/markdown-options.js
+++ b/src/js/markdown-options.js
@@ -6,7 +6,7 @@
     const moduleRegistry = getXlsx2mdModuleRegistry();
     const OUTPUT_MODES = ["display", "raw", "both"];
     const FORMATTING_MODES = ["plain", "github"];
-    const TABLE_DETECTION_MODES = ["balanced", "border"];
+    const TABLE_DETECTION_MODES = ["balanced", "border", "planner-aware"];
     const TABLE_DETECTION_MODE_ALIASES = {
         "border-priority": "border"
     };

--- a/src/js/sheet-markdown.js
+++ b/src/js/sheet-markdown.js
@@ -209,7 +209,8 @@
             return values.length >= 5 && values.every((value) => isIsoDateToken(value) || isWeekdayToken(value));
         }
         function blockHasCalendarDateItem(block) {
-            return !!block?.items?.some((item) => isCalendarDateItem(item));
+            var _a;
+            return !!((_a = block === null || block === void 0 ? void 0 : block.items) === null || _a === void 0 ? void 0 : _a.some((item) => isCalendarDateItem(item)));
         }
         function shouldAppendToCalendarNarrativeBlock(current, item, previousRow) {
             if (!current || !blockHasCalendarDateItem(current)) {
@@ -322,7 +323,7 @@
                 return true;
             }
             if (gap > verticalGapThreshold) {
-                const bothCalendarLike = !!(anchor.calendarLike && previousAnchor?.calendarLike);
+                const bothCalendarLike = !!(anchor.calendarLike && (previousAnchor === null || previousAnchor === void 0 ? void 0 : previousAnchor.calendarLike));
                 const horizontalGap = anchor.startCol - current.endCol;
                 if (!(bothCalendarLike && gap <= 8 && horizontalGap <= 24)) {
                     return true;
@@ -330,7 +331,7 @@
             }
             const overlapsCurrentRows = anchor.startRow <= current.endRow + 1;
             const horizontalGap = anchor.startCol - current.endCol;
-            const bothCalendarLike = !!(anchor.calendarLike && previousAnchor?.calendarLike);
+            const bothCalendarLike = !!(anchor.calendarLike && (previousAnchor === null || previousAnchor === void 0 ? void 0 : previousAnchor.calendarLike));
             if (bothCalendarLike && horizontalGap <= 24 && (overlapsCurrentRows || gap <= 8)) {
                 return false;
             }
@@ -553,7 +554,8 @@
             return ["日", "月", "火", "水", "木", "金", "土", "日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"].includes(normalized);
         }
         function getNarrativeValues(section) {
-            return section.narrativeBlock?.items.flatMap((item) => item.cellValues || []).map((value) => String(value || "").trim()).filter(Boolean) || [];
+            var _a;
+            return ((_a = section.narrativeBlock) === null || _a === void 0 ? void 0 : _a.items.flatMap((item) => item.cellValues || []).map((value) => String(value || "").trim()).filter(Boolean)) || [];
         }
         function isCalendarBodySection(section) {
             if (section.kind !== "narrative" || !section.narrativeBlock)

--- a/src/js/table-detector.js
+++ b/src/js/table-detector.js
@@ -178,22 +178,22 @@
             }
             return sparseRows;
         }
-    function maybePushCandidate(component, sourceKind = "border") {
-        const rows = component.map((entry) => entry.row);
-        const cols = component.map((entry) => entry.col);
+        function maybePushCandidate(component, sourceKind = "border") {
+            const rows = component.map((entry) => entry.row);
+            const cols = component.map((entry) => entry.col);
             const startRow = Math.min(...rows);
             const endRow = Math.max(...rows);
             const startCol = Math.min(...cols);
             const endCol = Math.max(...cols);
             const area = Math.max(1, (endRow - startRow + 1) * (endCol - startCol + 1));
             const density = component.filter((entry) => entry.outputValue.trim()).length / area;
-        const rowCount = endRow - startRow + 1;
-        const colCount = endCol - startCol + 1;
-        const sparseRowCount = countSparseRows(component, startRow, endRow);
-        const nonEmptyCells = component.filter((entry) => entry.outputValue.trim());
-        if (rowCount < 2 || colCount < 2) {
-            return;
-        }
+            const rowCount = endRow - startRow + 1;
+            const colCount = endCol - startCol + 1;
+            const sparseRowCount = countSparseRows(component, startRow, endRow);
+            const nonEmptyCells = component.filter((entry) => entry.outputValue.trim());
+            if (rowCount < 2 || colCount < 2) {
+                return;
+            }
             let score = 0;
             const reasons = [];
             const normalizedBorderedCellCount = borderGridHelper.countNormalizedBorderedCells(cellMap, startRow, startCol, endRow, endCol);
@@ -225,66 +225,71 @@
             const mergedArea = sheet.merges.filter((merge) => {
                 return !(merge.endRow < startRow || merge.startRow > endRow || merge.endCol < startCol || merge.startCol > endCol);
             }).length;
-        if (mergedArea >= Math.max(2, Math.ceil(area * 0.08))) {
-            score += scoreWeights.mergeHeavyPenalty;
-            reasons.push(`Many merged cells (${scoreWeights.mergeHeavyPenalty})`);
-        }
-        if (sourceKind === "border") {
-            const looksLikeTinyMergedLabelStub = (rowCount <= 2
-                && colCount <= 2
-                && mergedArea >= 1
-                && nonEmptyCells.length <= 2
-                && headerishCount <= 1);
-            if (looksLikeTinyMergedLabelStub) {
-                return;
+            if (mergedArea >= Math.max(2, Math.ceil(area * 0.08))) {
+                score += scoreWeights.mergeHeavyPenalty;
+                reasons.push(`Many merged cells (${scoreWeights.mergeHeavyPenalty})`);
             }
-            if (mergedArea >= 2 && density < 0.25 && headerishCount < 2) {
-                return;
+            const plannerAwareMode = tableDetectionMode === "planner-aware";
+            if (sourceKind === "border") {
+                const looksLikeTinyMergedLabelStub = (rowCount <= 2
+                    && colCount <= 2
+                    && mergedArea >= 1
+                    && nonEmptyCells.length <= 2
+                    && headerishCount <= 1);
+                if (looksLikeTinyMergedLabelStub) {
+                    return;
+                }
+                if (mergedArea >= 2 && density < 0.25 && headerishCount < 2) {
+                    return;
+                }
+                if (plannerAwareMode) {
+                    const looksLikeWideSparseMergeForm = (colCount >= 8
+                        && rowCount >= 4
+                        && density < 0.45
+                        && mergedArea >= Math.max(4, rowCount - 1)
+                        && sparseRowCount >= Math.ceil(rowCount * 0.7));
+                    if (looksLikeWideSparseMergeForm) {
+                        return;
+                    }
+                }
             }
-                const looksLikeWideSparseMergeForm = (colCount >= 8
-                    && rowCount >= 4
-                    && density < 0.45
-                    && mergedArea >= Math.max(4, rowCount - 1)
-                    && sparseRowCount >= Math.ceil(rowCount * 0.7));
-            if (looksLikeWideSparseMergeForm) {
-                return;
+            else {
+                if (mergedArea >= 2 && rowCount <= 6 && colCount >= 10 && density < 0.25) {
+                    return;
+                }
+                if (plannerAwareMode) {
+                    const looksLikeMixedLayoutSheet = (rowCount >= 20
+                        && colCount >= 8
+                        && mergedArea >= 4
+                        && sparseRowCount >= 4
+                        && density < 0.8);
+                    if (looksLikeMixedLayoutSheet) {
+                        return;
+                    }
+                }
             }
-        }
-        else {
-            if (mergedArea >= 2 && rowCount <= 6 && colCount >= 10 && density < 0.25) {
-                return;
-            }
-            const looksLikeMixedLayoutSheet = (rowCount >= 20
-                && colCount >= 8
-                && mergedArea >= 4
-                && sparseRowCount >= 4
-                && density < 0.8);
-            if (looksLikeMixedLayoutSheet) {
-                return;
-            }
-        }
-        const avgTextLength = nonEmptyCells
-            .reduce((sum, entry) => sum + entry.outputValue.trim().length, 0) / Math.max(1, nonEmptyCells.length);
+            const avgTextLength = nonEmptyCells
+                .reduce((sum, entry) => sum + entry.outputValue.trim().length, 0) / Math.max(1, nonEmptyCells.length);
             if (avgTextLength > 36 && density < 0.7) {
                 score += scoreWeights.prosePenalty;
                 reasons.push(`Mostly long prose (${scoreWeights.prosePenalty})`);
             }
-        if (score >= scoreWeights.threshold) {
-            const normalizedBounds = trimTableCandidateBounds(cellMap, {
-                startRow,
-                startCol,
-                endRow,
-                endCol
-            });
-            if (normalizedBounds.endRow - normalizedBounds.startRow + 1 < 2
-                || normalizedBounds.endCol - normalizedBounds.startCol + 1 < 2) {
-                return;
-            }
-            const key = `${normalizedBounds.startRow}:${normalizedBounds.startCol}:${normalizedBounds.endRow}:${normalizedBounds.endCol}`;
-            if (candidateKeys.has(key)) {
-                return;
-            }
-            candidateKeys.add(key);
+            if (score >= scoreWeights.threshold) {
+                const normalizedBounds = trimTableCandidateBounds(cellMap, {
+                    startRow,
+                    startCol,
+                    endRow,
+                    endCol
+                });
+                if (normalizedBounds.endRow - normalizedBounds.startRow + 1 < 2
+                    || normalizedBounds.endCol - normalizedBounds.startCol + 1 < 2) {
+                    return;
+                }
+                const key = `${normalizedBounds.startRow}:${normalizedBounds.startCol}:${normalizedBounds.endRow}:${normalizedBounds.endCol}`;
+                if (candidateKeys.has(key)) {
+                    return;
+                }
+                candidateKeys.add(key);
                 candidates.push({
                     startRow: normalizedBounds.startRow,
                     startCol: normalizedBounds.startCol,
@@ -319,7 +324,11 @@
                 maybePushCandidate(component, "fallback");
             }
         }
-        return pruneCalendarLikeColumnCandidates(pruneRedundantCandidates(candidates)).sort((left, right) => {
+        const prunedCandidates = pruneRedundantCandidates(candidates);
+        const finalCandidates = tableDetectionMode === "planner-aware"
+            ? pruneCalendarLikeColumnCandidates(prunedCandidates)
+            : prunedCandidates;
+        return finalCandidates.sort((left, right) => {
             if (left.startRow !== right.startRow)
                 return left.startRow - right.startRow;
             return left.startCol - right.startCol;

--- a/src/ts/core.ts
+++ b/src/ts/core.ts
@@ -213,7 +213,7 @@
     includeShapeDetails?: boolean;
     outputMode?: "display" | "raw" | "both";
     formattingMode?: "plain" | "github";
-    tableDetectionMode?: "balanced" | "border";
+    tableDetectionMode?: "balanced" | "border" | "planner-aware";
   };
 
   type ParseWorkbookOptions = {
@@ -227,7 +227,7 @@
     summary: {
       outputMode: "display" | "raw" | "both";
       formattingMode: "plain" | "github";
-      tableDetectionMode: "balanced" | "border";
+      tableDetectionMode: "balanced" | "border" | "planner-aware";
       sections: number;
       tables: number;
       narrativeBlocks: number;
@@ -423,7 +423,7 @@
     detectTableCandidates: (
       sheet: ParsedSheet,
       buildCellMapForSheet: (sheet: ParsedSheet) => Map<string, ParsedCell>,
-      tableDetectionMode: "balanced" | "border" = "balanced"
+      tableDetectionMode: "balanced" | "border" | "planner-aware" = "balanced"
     ) => tableDetectorHelper.detectTableCandidates(sheet, buildCellMapForSheet, undefined, tableDetectionMode),
     matrixFromCandidate: tableDetectorHelper.matrixFromCandidate,
     renderMarkdownTable: markdownExportHelper.renderMarkdownTable,
@@ -621,7 +621,7 @@
     applyMergeTokens: tableDetectorHelper.applyMergeTokens,
     detectTableCandidates: (
       sheet: ParsedSheet,
-      tableDetectionMode: "balanced" | "border" | string = "balanced"
+      tableDetectionMode: "balanced" | "border" | "planner-aware" | string = "balanced"
     ) => tableDetectorHelper.detectTableCandidates(
       sheet,
       buildCellMap,

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -12,7 +12,7 @@
     includeShapeDetails: boolean;
     outputMode: "display" | "raw" | "both";
     formattingMode: "plain" | "github";
-    tableDetectionMode: "balanced" | "border";
+    tableDetectionMode: "balanced" | "border" | "planner-aware";
   };
   type MarkdownEncoding = "utf-8" | "shift_jis" | "utf-16le" | "utf-16be" | "utf-32le" | "utf-32be";
   type MarkdownBomMode = "off" | "on";
@@ -28,7 +28,7 @@
     summary: {
       outputMode: "display" | "raw" | "both";
       formattingMode: "plain" | "github";
-      tableDetectionMode: "balanced" | "border";
+      tableDetectionMode: "balanced" | "border" | "planner-aware";
       tables: number;
       narrativeBlocks: number;
       merges: number;
@@ -362,8 +362,12 @@
     notice.textContent = "`plain` strips Excel text emphasis and outputs plain Markdown text.";
   }
 
-  function updateTableDetectionModeNotice(mode: "balanced" | "border"): void {
+  function updateTableDetectionModeNotice(mode: "balanced" | "border" | "planner-aware"): void {
     const notice = getElement<HTMLElement>("tableDetectionModeNotice");
+    if (mode === "planner-aware") {
+      notice.textContent = "`planner-aware` adds planner/calendar-specific suppression heuristics for layout-heavy sheets.";
+      return;
+    }
     if (mode === "border") {
       notice.textContent = "`border` detects tables from bordered regions and suppresses borderless fallback detection.";
       return;

--- a/src/ts/markdown-export.ts
+++ b/src/ts/markdown-export.ts
@@ -28,7 +28,7 @@
     summary: {
       outputMode: "display" | "raw" | "both";
       formattingMode: "plain" | "github";
-      tableDetectionMode: "balanced" | "border";
+      tableDetectionMode: "balanced" | "border" | "planner-aware";
       sections: number;
       tables: number;
       narrativeBlocks: number;

--- a/src/ts/markdown-options.ts
+++ b/src/ts/markdown-options.ts
@@ -14,7 +14,7 @@
     includeShapeDetails?: boolean;
     outputMode?: "display" | "raw" | "both" | string;
     formattingMode?: "plain" | "github" | string;
-    tableDetectionMode?: "balanced" | "border" | string;
+    tableDetectionMode?: "balanced" | "border" | "planner-aware" | string;
   };
 
   type ResolvedMarkdownOptions = {
@@ -25,13 +25,13 @@
     includeShapeDetails: boolean;
     outputMode: "display" | "raw" | "both";
     formattingMode: "plain" | "github";
-    tableDetectionMode: "balanced" | "border";
+    tableDetectionMode: "balanced" | "border" | "planner-aware";
   };
 
   const OUTPUT_MODES = ["display", "raw", "both"] as const;
   const FORMATTING_MODES = ["plain", "github"] as const;
-  const TABLE_DETECTION_MODES = ["balanced", "border"] as const;
-  const TABLE_DETECTION_MODE_ALIASES: Record<string, "balanced" | "border"> = {
+  const TABLE_DETECTION_MODES = ["balanced", "border", "planner-aware"] as const;
+  const TABLE_DETECTION_MODE_ALIASES: Record<string, "balanced" | "border" | "planner-aware"> = {
     "border-priority": "border"
   };
 
@@ -63,7 +63,7 @@
     return normalizeEnum(value, FORMATTING_MODES, "plain");
   }
 
-  function normalizeTableDetectionMode(value?: string | null): "balanced" | "border" {
+  function normalizeTableDetectionMode(value?: string | null): "balanced" | "border" | "planner-aware" {
     return normalizeEnum(value, TABLE_DETECTION_MODES, "balanced", TABLE_DETECTION_MODE_ALIASES);
   }
 

--- a/src/ts/module-registry-access.ts
+++ b/src/ts/module-registry-access.ts
@@ -46,11 +46,11 @@
   type MarkdownOptionsApi = {
     OUTPUT_MODES: readonly ["display", "raw", "both"];
     FORMATTING_MODES: readonly ["plain", "github"];
-    TABLE_DETECTION_MODES: readonly ["balanced", "border"];
-    TABLE_DETECTION_MODE_ALIASES: Record<string, "balanced" | "border">;
+    TABLE_DETECTION_MODES: readonly ["balanced", "border", "planner-aware"];
+    TABLE_DETECTION_MODE_ALIASES: Record<string, "balanced" | "border" | "planner-aware">;
     normalizeOutputMode: (value?: string | null) => "display" | "raw" | "both";
     normalizeFormattingMode: (value?: string | null) => "plain" | "github";
-    normalizeTableDetectionMode: (value?: string | null) => "balanced" | "border";
+    normalizeTableDetectionMode: (value?: string | null) => "balanced" | "border" | "planner-aware";
     resolveMarkdownOptions: (options?: {
       treatFirstRowAsHeader?: boolean;
       trimText?: boolean;
@@ -59,7 +59,7 @@
       includeShapeDetails?: boolean;
       outputMode?: "display" | "raw" | "both" | string;
       formattingMode?: "plain" | "github" | string;
-      tableDetectionMode?: "balanced" | "border" | string;
+      tableDetectionMode?: "balanced" | "border" | "planner-aware" | string;
     }) => {
       treatFirstRowAsHeader: boolean;
       trimText: boolean;
@@ -68,7 +68,7 @@
       includeShapeDetails: boolean;
       outputMode: "display" | "raw" | "both";
       formattingMode: "plain" | "github";
-      tableDetectionMode: "balanced" | "border";
+      tableDetectionMode: "balanced" | "border" | "planner-aware";
     };
   };
   type Xlsx2mdRichTextParserModule<TCell> = {
@@ -226,7 +226,7 @@
         prosePenalty: number;
         threshold: number;
       },
-      tableDetectionMode?: "balanced" | "border"
+      tableDetectionMode?: "balanced" | "border" | "planner-aware"
     ) => TCandidate[];
     matrixFromCandidate: (
       sheet: TSheet,

--- a/src/ts/sheet-markdown.ts
+++ b/src/ts/sheet-markdown.ts
@@ -143,7 +143,7 @@
     includeShapeDetails?: boolean;
     outputMode?: "display" | "raw" | "both";
     formattingMode?: "plain" | "github";
-    tableDetectionMode?: "balanced" | "border";
+    tableDetectionMode?: "balanced" | "border" | "planner-aware";
   };
 
   type TableCandidate = {
@@ -223,7 +223,7 @@
     summary: {
       outputMode: "display" | "raw" | "both";
       formattingMode: "plain" | "github";
-      tableDetectionMode: "balanced" | "border";
+      tableDetectionMode: "balanced" | "border" | "planner-aware";
       sections: number;
       tables: number;
       narrativeBlocks: number;
@@ -251,7 +251,7 @@
     detectTableCandidates: (
       sheet: ParsedSheet,
       buildCellMap: (sheet: ParsedSheet) => Map<string, ParsedCell>,
-      tableDetectionMode?: "balanced" | "border"
+      tableDetectionMode?: "balanced" | "border" | "planner-aware"
     ) => TableCandidate[];
     matrixFromCandidate: (
       sheet: ParsedSheet,

--- a/src/ts/table-detector.ts
+++ b/src/ts/table-detector.ts
@@ -47,7 +47,7 @@
     removeEmptyColumns?: boolean;
   };
 
-  type TableDetectionMode = "balanced" | "border";
+  type TableDetectionMode = "balanced" | "border" | "planner-aware";
 
   type TableScoreWeights = {
     minGrid: number;
@@ -319,6 +319,8 @@
         reasons.push(`Many merged cells (${scoreWeights.mergeHeavyPenalty})`);
       }
 
+      const plannerAwareMode = tableDetectionMode === "planner-aware";
+
       if (sourceKind === "border") {
         const looksLikeTinyMergedLabelStub = (
           rowCount <= 2
@@ -333,29 +335,33 @@
         if (mergedArea >= 2 && density < 0.25 && headerishCount < 2) {
           return;
         }
-        const looksLikeWideSparseMergeForm = (
-          colCount >= 8
-          && rowCount >= 4
-          && density < 0.45
-          && mergedArea >= Math.max(4, rowCount - 1)
-          && sparseRowCount >= Math.ceil(rowCount * 0.7)
-        );
-        if (looksLikeWideSparseMergeForm) {
-          return;
+        if (plannerAwareMode) {
+          const looksLikeWideSparseMergeForm = (
+            colCount >= 8
+            && rowCount >= 4
+            && density < 0.45
+            && mergedArea >= Math.max(4, rowCount - 1)
+            && sparseRowCount >= Math.ceil(rowCount * 0.7)
+          );
+          if (looksLikeWideSparseMergeForm) {
+            return;
+          }
         }
       } else {
         if (mergedArea >= 2 && rowCount <= 6 && colCount >= 10 && density < 0.25) {
           return;
         }
-        const looksLikeMixedLayoutSheet = (
-          rowCount >= 20
-          && colCount >= 8
-          && mergedArea >= 4
-          && sparseRowCount >= 4
-          && density < 0.8
-        );
-        if (looksLikeMixedLayoutSheet) {
-          return;
+        if (plannerAwareMode) {
+          const looksLikeMixedLayoutSheet = (
+            rowCount >= 20
+            && colCount >= 8
+            && mergedArea >= 4
+            && sparseRowCount >= 4
+            && density < 0.8
+          );
+          if (looksLikeMixedLayoutSheet) {
+            return;
+          }
         }
       }
 
@@ -423,7 +429,12 @@
       }
     }
 
-    return pruneCalendarLikeColumnCandidates(pruneRedundantCandidates(candidates)).sort((left, right) => {
+    const prunedCandidates = pruneRedundantCandidates(candidates);
+    const finalCandidates = tableDetectionMode === "planner-aware"
+      ? pruneCalendarLikeColumnCandidates(prunedCandidates)
+      : prunedCandidates;
+
+    return finalCandidates.sort((left, right) => {
       if (left.startRow !== right.startRow) return left.startRow - right.startRow;
       return left.startCol - right.startCol;
     });

--- a/tests/xlsx2md-cli.test.js
+++ b/tests/xlsx2md-cli.test.js
@@ -109,6 +109,9 @@ describe("xlsx2md cli", () => {
     expect(result.stdout).toContain("--bom");
     expect(result.stdout).toContain("--formatting-mode");
     expect(result.stdout).toContain("--table-detection-mode");
+    expect(result.stdout).toContain("GUI-aligned defaults:");
+    expect(result.stdout).toContain("formatting-mode=github");
+    expect(result.stdout).toContain("shape-details=exclude");
     expect(result.stdout).toContain("Exit codes:");
   });
 

--- a/tests/xlsx2md-main-ui.test.js
+++ b/tests/xlsx2md-main-ui.test.js
@@ -20,7 +20,7 @@ function createDomFixture() {
     <input id="trimTextEnabled" type="checkbox" checked />
     <input id="removeEmptyRowsEnabled" type="checkbox" checked />
     <input id="removeEmptyColumnsEnabled" type="checkbox" checked />
-    <input id="includeShapeDetailsEnabled" type="checkbox" checked />
+    <input id="includeShapeDetailsEnabled" type="checkbox" />
     <select id="outputModeSelect">
       <option value="display" selected>display</option>
       <option value="raw">raw</option>
@@ -42,6 +42,7 @@ function createDomFixture() {
     <select id="tableDetectionModeSelect">
       <option value="balanced" selected>balanced</option>
       <option value="border">border</option>
+      <option value="planner-aware">planner-aware</option>
     </select>
     <div id="outputModeNotice"></div>
     <div id="formattingModeNotice"></div>
@@ -185,7 +186,7 @@ describe("xlsx2md main ui", () => {
 
   it("loads a workbook from the file input and passes UI options to conversion", async () => {
     const api = bootMain();
-    document.getElementById("includeShapeDetailsEnabled").checked = false;
+    document.getElementById("includeShapeDetailsEnabled").checked = true;
     document.getElementById("outputModeSelect").value = "both";
     document.getElementById("formattingModeSelect").value = "github";
     document.getElementById("tableDetectionModeSelect").value = "border";
@@ -203,11 +204,11 @@ describe("xlsx2md main ui", () => {
     fileInput.dispatchEvent(new Event("change"));
     await flushAsyncWork();
 
-    expect(api.parseWorkbook).toHaveBeenCalledWith(expect.any(ArrayBuffer), "sample.xlsx", { includeShapeDetails: false });
+    expect(api.parseWorkbook).toHaveBeenCalledWith(expect.any(ArrayBuffer), "sample.xlsx", { includeShapeDetails: true });
     expect(api.convertWorkbookToMarkdownFiles).toHaveBeenCalledWith(
       expect.objectContaining({ name: "book.xlsx" }),
       expect.objectContaining({
-        includeShapeDetails: false,
+        includeShapeDetails: true,
         outputMode: "both",
         formattingMode: "github",
         tableDetectionMode: "border",
@@ -253,10 +254,10 @@ describe("xlsx2md main ui", () => {
     await flushAsyncWork();
     api.parseWorkbook.mockClear();
 
-    document.getElementById("includeShapeDetailsEnabled").checked = false;
+    document.getElementById("includeShapeDetailsEnabled").checked = true;
     document.getElementById("convertBtn").click();
     await flushAsyncWork();
 
-    expect(api.parseWorkbook).toHaveBeenCalledWith(expect.any(ArrayBuffer), "sample.xlsx", { includeShapeDetails: false });
+    expect(api.parseWorkbook).toHaveBeenCalledWith(expect.any(ArrayBuffer), "sample.xlsx", { includeShapeDetails: true });
   });
 });

--- a/tests/xlsx2md-main.test.js
+++ b/tests/xlsx2md-main.test.js
@@ -215,8 +215,8 @@ describe("xlsx2md core", () => {
     expect(markdownFile.markdown).toContain("| 10 | 指数 | value9 | 1.023456E+06 | 指数 |");
     expect(markdownFile.markdown).toContain("| 12 | その他 | value11 | 1 0 2 3 4 5 6 | その他 |");
     expect(markdownFile.markdown).toContain("| 13 | ユーザー定義 | value12 | 令和8年3月17日 | ユーザー定義 |");
-    expect(markdownFile.markdown).toContain("[MERGED←]");
-    expect(markdownFile.markdown).toContain("[MERGED↑]");
+    expect(markdownFile.markdown).toContain("[←M←]");
+    expect(markdownFile.markdown).toContain("[↑M↑]");
   });
 
   it("parses the display-format fixture workbook with concrete display expectations", async () => {
@@ -445,14 +445,14 @@ describe("xlsx2md core", () => {
     expect(markdownFile.markdown).toContain("### Table: 001 (A1-E4)");
     expect(markdownFile.markdown).toContain("### Table: 002 (A7-D11)");
     expect(markdownFile.markdown).toContain("### Table: 003 (A14-E18)");
-    expect(markdownFile.markdown).toContain("| 1 | 横結合 | [MERGED←] | 横結合 | [MERGED←] |");
-    expect(markdownFile.markdown).toContain("| 2 | [MERGED↑] | [MERGED↑] | [MERGED↑] |");
-    expect(markdownFile.markdown).toContain("| 1 | 2x2結合 | [MERGED←] | 2x2結合 | [MERGED←] |");
+    expect(markdownFile.markdown).toContain("| 1 | 横結合 | [←M←] | 横結合 | [←M←] |");
+    expect(markdownFile.markdown).toContain("| 2 | [↑M↑] | [↑M↑] | [↑M↑] |");
+    expect(markdownFile.markdown).toContain("| 1 | 2x2結合 | [←M←] | 2x2結合 | [←M←] |");
     expect(markdownFile.markdown).toContain("※横結合のサンプルです");
     expect(markdownFile.markdown).toContain("※縦結合のサンプルです");
     expect(markdownFile.markdown).toContain("※2x2結合のサンプルです");
-    expect(markdownFile.markdown).toContain("[MERGED←]");
-    expect(markdownFile.markdown).toContain("[MERGED↑]");
+    expect(markdownFile.markdown).toContain("[←M←]");
+    expect(markdownFile.markdown).toContain("[↑M↑]");
   });
 
   it("parses the merge-multiline fixture workbook with concrete multiline-merge expectations", async () => {
@@ -496,8 +496,8 @@ describe("xlsx2md core", () => {
     expect(markdownFile.markdown).toContain("## Sheet: merge-multiline");
     expect(markdownFile.markdown).toContain("# Book: merge-multiline-sample01.xlsx");
     expect(markdownFile.markdown).toContain("### Table: 001 (A1-C4)");
-    expect(markdownFile.markdown).toContain("| 1 | 1行目 2行目 | [MERGED←] |");
-    expect(markdownFile.markdown).toContain("| 2 | [MERGED↑] | [MERGED↑] |");
+    expect(markdownFile.markdown).toContain("| 1 | 1行目 2行目 | [←M←] |");
+    expect(markdownFile.markdown).toContain("| 2 | [↑M↑] | [↑M↑] |");
     expect(markdownFile.markdown).toContain("※結合セル内の改行確認用");
   });
 
@@ -2284,7 +2284,7 @@ describe("xlsx2md core", () => {
     expect(markdownFile.markdown).toContain("# Book: table-basic-sample15.xlsx");
     expect(markdownFile.markdown).toContain("### Table: 001 (B3-T7)");
     expect(markdownFile.markdown).toContain("| 3 | 登録日 | entrydate | 3月13日 | 登録および更新日 |");
-    expect(markdownFile.markdown).toContain("| 4 | 更新日 | updatedate | 3月14日 | [MERGED↑] |");
+    expect(markdownFile.markdown).toContain("| 4 | 更新日 | updatedate | 3月14日 | [↑M↑] |");
     expect(markdownFile.markdown).toContain("※方眼紙＋結合＋さらに縦結合");
   });
 
@@ -2326,7 +2326,7 @@ describe("xlsx2md core", () => {
     expect(markdownFile.summary.tableScores.map((detail) => detail.range)).toEqual(["B3-T7"]);
     expect(markdownFile.markdown).toContain("# Book: table-basic-sample16.xlsx");
     expect(markdownFile.markdown).toContain("### Table: 001 (B3-T7)");
-    expect(markdownFile.markdown).toContain("| 項番 | 項目名称 | 物理名 | デフォルト値 | [MERGED←] | 備考 |");
+    expect(markdownFile.markdown).toContain("| 項番 | 項目名称 | 物理名 | デフォルト値 | [←M←] | 備考 |");
     expect(markdownFile.markdown).toContain("| 2 | 名前 | name | Taro | Ito | 何かの名前 |");
     expect(markdownFile.markdown).toContain("たまに結合漏れのセルがあって、さらに複数文字が登場");
   });
@@ -2451,10 +2451,10 @@ describe("xlsx2md core", () => {
       { startRow: 1, startCol: 1, endRow: 2, endCol: 3, ref: "A1:C2" }
     ], 1, 1, 3, 3);
 
-    expect(matrix[0][1]).toBe("[MERGED←]");
-    expect(matrix[0][2]).toBe("[MERGED←]");
-    expect(matrix[1][0]).toBe("[MERGED↑]");
-    expect(matrix[1][2]).toBe("[MERGED↑]");
+    expect(matrix[0][1]).toBe("[←M←]");
+    expect(matrix[0][2]).toBe("[←M←]");
+    expect(matrix[1][0]).toBe("[↑M↑]");
+    expect(matrix[1][2]).toBe("[↑M↑]");
   });
 
   it("extracts narrative blocks outside tables", () => {
@@ -3309,7 +3309,7 @@ describe("xlsx2md core", () => {
     expect(markdownFile.markdown).not.toContain("イベント チェックリスト イベント カテゴリ");
   });
 
-  it("does not turn repeated narrow calendar-like columns into many small tables", () => {
+  it("planner-aware does not turn repeated narrow calendar-like columns into many small tables", () => {
     const api = bootCore();
     const workbook = { name: "calendar-layout.xlsx" };
     const sheet = {
@@ -3356,7 +3356,7 @@ describe("xlsx2md core", () => {
       removeEmptyRows: true,
       removeEmptyColumns: true,
       treatFirstRowAsHeader: true,
-      tableDetectionMode: "border"
+      tableDetectionMode: "planner-aware"
     });
 
     expect(markdownFile.summary.tables).toBe(0);

--- a/tests/xlsx2md-node-runtime.test.js
+++ b/tests/xlsx2md-node-runtime.test.js
@@ -46,6 +46,7 @@ describe("xlsx2md node runtime", () => {
 
     expect(api.markdownOptions.OUTPUT_MODES).toContain("display");
     expect(api.markdownOptions.FORMATTING_MODES).toContain("github");
+    expect(api.markdownOptions.TABLE_DETECTION_MODES).toContain("planner-aware");
     expect(api.markdownOptions.normalizeTableDetectionMode("border-priority")).toBe("border");
   });
 });

--- a/tests/xlsx2md-table-detector.test.js
+++ b/tests/xlsx2md-table-detector.test.js
@@ -278,7 +278,7 @@ describe("xlsx2md table detector", () => {
     expect(candidates).toHaveLength(0);
   });
 
-  it("drops calendar-like narrow table candidates when many columns line up in the same band", () => {
+  it("planner-aware drops calendar-like narrow table candidates when many columns line up in the same band", () => {
     const api = bootTableDetector();
     const sheet = {
       cells: [
@@ -312,7 +312,7 @@ describe("xlsx2md table detector", () => {
       merges: []
     };
 
-    const candidates = api.detectTableCandidates(sheet, buildCellMap, undefined, "border");
+    const candidates = api.detectTableCandidates(sheet, buildCellMap, undefined, "planner-aware");
 
     expect(candidates).toHaveLength(0);
   });
@@ -334,7 +334,7 @@ describe("xlsx2md table detector", () => {
     expect(candidates).toHaveLength(0);
   });
 
-  it("does not keep a huge fallback candidate for a merge-heavy mixed layout sheet", () => {
+  it("planner-aware does not keep a huge fallback candidate for a merge-heavy mixed layout sheet", () => {
     const api = bootTableDetector();
     const cells = [];
     for (let row = 1; row <= 24; row += 1) {
@@ -355,7 +355,7 @@ describe("xlsx2md table detector", () => {
       ]
     };
 
-    const candidates = api.detectTableCandidates(sheet, buildCellMap, undefined, "balanced");
+    const candidates = api.detectTableCandidates(sheet, buildCellMap, undefined, "planner-aware");
 
     expect(candidates).toHaveLength(0);
   });


### PR DESCRIPTION
## 概要

- テーブル検知モードに `planner-aware` を追加
- `planner-aware` 向けの planner / calendar 系抑制ヒューリスティックを分離
- GUI / CLI / README のモード説明を更新
- GUI / CLI の既定値を整備し、ヘルプ表示を更新
- `markdownOptions` モジュールの読み込みを HTML に追加
- 関連テストを更新

## 変更内容

### テーブル検知まわり

- `balanced` / `border` に加えて `planner-aware` を追加
- `markdown-options`、`module-registry-access`、`core`、`sheet-markdown`、`markdown-export` などで `planner-aware` を扱えるように変更
- `table-detector` で `planner-aware` 時のみ planner / calendar 系の抑制ロジックを適用するように変更
- `pruneCalendarLikeColumnCandidates(...)` の適用を `planner-aware` に限定
- `border` / `balanced` と `planner-aware` の責務差が出るように整理

### GUI / CLI / ドキュメント

- GUI の Table Detection 選択肢に `planner-aware` を追加
- GUI の table detection 説明文を更新
- CLI の `--table-detection-mode` ヘルプに `planner-aware` を追加
- CLI ヘルプに GUI と揃えた既定値表示を追加
- README の英日両方で、`planner-aware` の説明と CLI 既定値の説明を更新
- GUI の shape details 既定値を OFF に変更
- CLI の shape details 既定値を `exclude` に変更

### その他

- `miku-xlsx2md-src.html` に `src/js/markdown-options.js` の読み込みを追加
- 生成物の `index.html` / `miku-xlsx2md.html` を更新
- merge marker に関するテスト期待値を `[←M←]` / `[↑M↑]` に更新

## テスト

- `tests/xlsx2md-cli.test.js`
- `tests/xlsx2md-main-ui.test.js`
- `tests/xlsx2md-main.test.js`
- `tests/xlsx2md-node-runtime.test.js`
- `tests/xlsx2md-table-detector.test.js`