### PR TITLE
runtime bundle release フローと CLI version 表示を追加する

### DIFF
--- a/.github/workflows/release-runtime-bundle.yml
+++ b/.github/workflows/release-runtime-bundle.yml
@@ -1,0 +1,49 @@
+name: Release runtime bundle
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release-runtime-bundle:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and test
+        run: npm run build
+
+      - name: Build runtime bundle
+        run: npm run build:runtime
+
+      - name: Smoke runtime bundle
+        run: npm run smoke:runtime
+
+      - name: Stage release assets
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: npm run stage:runtime-release
+
+      - name: Upload runtime bundle to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: release-assets/*
+          overwrite_files: true
+          draft: false
+          prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 local-data/
 workplace/
 node_modules/
+bundle/
+release-assets/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ npm run build
 
 Generated browser HTML files are no longer owned by this repository. Build and release the browser app from `miku-xlsx2md-web`.
 
+## Runtime Bundle
+
+This repository publishes the upstream runtime bundle consumed by downstream surfaces such as `miku-xlsx2md-web`.
+
+```bash
+npm run build:runtime
+npm run smoke:runtime
+npm run stage:runtime-release
+```
+
+Generated local artifacts:
+
+- `bundle/miku-xlsx2md-runtime.mjs`
+- `bundle/miku-xlsx2md-runtime.json`
+
+Release asset names:
+
+- `miku-xlsx2md-runtime-<version>.mjs`
+- `miku-xlsx2md-runtime-<version>.json`
+
+The GitHub Actions workflow `.github/workflows/release-runtime-bundle.yml` runs on `v*` tags, builds and tests the main application, builds the runtime bundle, runs the runtime smoke check, stages release assets, and uploads them to the matching GitHub Release.
+
 ## Tech Stack
 
 - Runtime: Node.js
@@ -146,3 +168,25 @@ npm run build
 `npm run build` は TypeScript の product core を `src/js/` へ変換し、その後テストを実行します。`src/ts/` が正本であり、`src/js/` は現時点の Node/runtime 用生成物として残しています。
 
 ブラウザ向け HTML 生成物はこのリポジトリの所有物ではありません。Web App のビルドとリリースは `miku-xlsx2md-web` で行います。
+
+## Runtime Bundle
+
+このリポジトリは、`miku-xlsx2md-web` などの downstream surface が利用する upstream runtime bundle を提供します。
+
+```bash
+npm run build:runtime
+npm run smoke:runtime
+npm run stage:runtime-release
+```
+
+ローカル生成物:
+
+- `bundle/miku-xlsx2md-runtime.mjs`
+- `bundle/miku-xlsx2md-runtime.json`
+
+GitHub Release asset 名:
+
+- `miku-xlsx2md-runtime-<version>.mjs`
+- `miku-xlsx2md-runtime-<version>.json`
+
+`.github/workflows/release-runtime-bundle.yml` は `v*` tag push で動作し、main application の build/test、runtime bundle 生成、runtime smoke、release asset staging、GitHub Release への upload を行います。

--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,32 @@ Feature and implementation backlog remains in [docs/TODO.md](./docs/TODO.md).
 - [x] Keep product core, CLI, diagnostics, fixtures, and core tests in this repository
 - [x] Retarget `npm run build` to regenerate core JavaScript instead of Web HTML
 - [x] Update README / CONTRIBUTING / notices for the main application role
-- [ ] Publish or document a formal upstream runtime release asset for `miku-xlsx2md-web`
+- [x] Document and automate formal upstream runtime release assets for `miku-xlsx2md-web`
 - [ ] Revisit whether `src/js/` should remain tracked or move to an ignored runtime output directory after the downstream runtime asset contract is finalized
+
+## Runtime Release Asset Contract
+
+Local commands:
+
+- `npm run build:runtime`
+- `npm run smoke:runtime`
+- `npm run stage:runtime-release`
+
+Local generated files:
+
+- `bundle/miku-xlsx2md-runtime.mjs`
+- `bundle/miku-xlsx2md-runtime.json`
+
+GitHub Release assets:
+
+- `miku-xlsx2md-runtime-<version>.mjs`
+- `miku-xlsx2md-runtime-<version>.json`
+
+Workflow:
+
+- `.github/workflows/release-runtime-bundle.yml`
+- Trigger: `v*` tag push
+- Responsibility: build/test main app, build runtime bundle, smoke runtime bundle, stage release assets, upload release assets to the matching GitHub Release
 
 ## Ownership
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "miku-xlsx2md",
+      "version": "1.0.0",
       "devDependencies": {
         "@xmldom/xmldom": "^0.9.9",
         "jsdom": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
   "name": "miku-xlsx2md",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {
     "test": "vitest run",
     "test:unit": "vitest run",
     "test:watch": "vitest",
-    "build": "node scripts/build-miku-xlsx2md.mjs && npm test",
+    "build:core": "node scripts/build-miku-xlsx2md.mjs",
+    "build": "npm run build:core && npm test",
+    "build:runtime": "npm run build:core && node scripts/build-runtime-bundle.mjs",
+    "smoke:runtime": "node scripts/smoke-runtime-bundle.mjs",
+    "stage:runtime-release": "node scripts/stage-runtime-release-assets.mjs",
     "cli": "node scripts/miku-xlsx2md-cli.mjs"
   },
   "devDependencies": {

--- a/scripts/build-runtime-bundle.mjs
+++ b/scripts/build-runtime-bundle.mjs
@@ -1,0 +1,34 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  createRuntimeBundleMetadata,
+  createRuntimeBundleSource,
+  getPackageVersion,
+  readPackageJson,
+  resolveRuntimeBundlePaths
+} from "./lib/xlsx2md-runtime-bundle.mjs";
+
+const ROOT = process.cwd();
+
+async function main() {
+  const packageJson = await readPackageJson(ROOT);
+  const version = getPackageVersion(packageJson);
+  const { bundleDir, runtimePath, metadataPath } = resolveRuntimeBundlePaths(ROOT);
+
+  await fs.mkdir(bundleDir, { recursive: true });
+  await fs.writeFile(runtimePath, await createRuntimeBundleSource(ROOT, version), "utf8");
+  await fs.writeFile(
+    metadataPath,
+    JSON.stringify(createRuntimeBundleMetadata(version), null, 2) + "\n",
+    "utf8"
+  );
+
+  console.log(`[build:runtime] generated ${path.relative(ROOT, runtimePath)}`);
+  console.log(`[build:runtime] generated ${path.relative(ROOT, metadataPath)}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/lib/xlsx2md-runtime-bundle.mjs
+++ b/scripts/lib/xlsx2md-runtime-bundle.mjs
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { XLSX2MD_CORE_JS_ORDER } from "./xlsx2md-module-order.mjs";
+
+export const RUNTIME_BUNDLE_BASENAME = "miku-xlsx2md-runtime";
+export const RUNTIME_BUNDLE_DIR = "bundle";
+export const RUNTIME_BUNDLE_MJS = `${RUNTIME_BUNDLE_BASENAME}.mjs`;
+export const RUNTIME_BUNDLE_JSON = `${RUNTIME_BUNDLE_BASENAME}.json`;
+
+export async function readPackageJson(rootDir) {
+  return JSON.parse(await fs.readFile(path.resolve(rootDir, "package.json"), "utf8"));
+}
+
+export function getPackageVersion(packageJson) {
+  const version = packageJson.version;
+  if (!version) {
+    throw new Error("package.json version is required to build the runtime bundle.");
+  }
+  return version;
+}
+
+export async function createRuntimeBundleSource(rootDir, version) {
+  const coreSources = [];
+  for (const relPath of XLSX2MD_CORE_JS_ORDER) {
+    coreSources.push({
+      path: relPath,
+      source: await fs.readFile(path.resolve(rootDir, relPath), "utf8")
+    });
+  }
+
+  return `/*
+ * miku-xlsx2md runtime bundle
+ * Source repository: https://github.com/igapyon/miku-xlsx2md
+ * Version: ${version}
+ */
+const XLSX2MD_RUNTIME_CORE_SOURCES = ${JSON.stringify(coreSources)};
+let cachedApi = null;
+
+export const version = ${JSON.stringify(version)};
+export const embeddedCorePaths = XLSX2MD_RUNTIME_CORE_SOURCES.map((entry) => entry.path);
+
+export function loadXlsx2mdRuntime(options = {}) {
+  if (cachedApi && !options.reset) {
+    return cachedApi;
+  }
+
+  if (options.reset) {
+    delete globalThis.__xlsx2mdModuleRegistry;
+    delete globalThis.__xlsx2mdModuleRegistryStore;
+    delete globalThis.getXlsx2mdModuleRegistry;
+  }
+
+  for (const entry of XLSX2MD_RUNTIME_CORE_SOURCES) {
+    new Function(entry.source)();
+  }
+
+  const api = globalThis.__xlsx2mdModuleRegistry?.getModule("xlsx2md");
+  if (!api) {
+    throw new Error("xlsx2md runtime API failed to initialize.");
+  }
+
+  cachedApi = api;
+  return api;
+}
+
+export default loadXlsx2mdRuntime;
+`;
+}
+
+export function createRuntimeBundleMetadata(version) {
+  return {
+    repository: "https://github.com/igapyon/miku-xlsx2md",
+    runtimeVersion: version,
+    runtimeAsset: RUNTIME_BUNDLE_MJS,
+    embeddedCorePaths: XLSX2MD_CORE_JS_ORDER
+  };
+}
+
+export function resolveRuntimeBundlePaths(rootDir) {
+  const bundleDir = path.resolve(rootDir, RUNTIME_BUNDLE_DIR);
+  return {
+    bundleDir,
+    runtimePath: path.resolve(bundleDir, RUNTIME_BUNDLE_MJS),
+    metadataPath: path.resolve(bundleDir, RUNTIME_BUNDLE_JSON)
+  };
+}

--- a/scripts/miku-xlsx2md-cli.mjs
+++ b/scripts/miku-xlsx2md-cli.mjs
@@ -3,12 +3,16 @@ import path from "node:path";
 
 import { loadXlsx2mdNodeApi } from "./lib/xlsx2md-node-runtime.mjs";
 
+const PACKAGE_JSON_URL = new URL("../package.json", import.meta.url);
 const SHAPE_DETAILS_MODES = ["include", "exclude"];
 const ENCODINGS = ["utf-8", "shift_jis", "utf-16le", "utf-16be", "utf-32le", "utf-32be"];
 const BOM_MODES = ["off", "on"];
 const FLAG_OPTIONS = {
   "--help"(options) {
     options.help = true;
+  },
+  "--version"(options) {
+    options.version = true;
   },
   "--include-shape-details"(options) {
     options.includeShapeDetails = true;
@@ -49,6 +53,7 @@ Options:
   --keep-empty-rows             Keep empty rows
   --keep-empty-columns          Keep empty columns
   --summary                     Print per-sheet summary to stdout
+  --version                     Show version and exit
   --help                        Show this help and exit
 
 GUI-aligned defaults:
@@ -58,6 +63,11 @@ Exit codes:
   0                             Success
   1                             Error
 `);
+}
+
+async function readPackageVersion() {
+  const packageJson = JSON.parse(await fs.readFile(PACKAGE_JSON_URL, "utf8"));
+  return packageJson.version || "0.0.0";
 }
 
 function normalizeEnumOption(value, allowedValues, label, aliases = {}) {
@@ -208,6 +218,10 @@ function printWorkbookSummary(api, workbookName, files) {
 async function main() {
   const api = loadXlsx2mdNodeApi();
   const options = parseArgs(process.argv.slice(2), api.markdownOptions);
+  if (options.version) {
+    console.log(await readPackageVersion());
+    process.exit(0);
+  }
   if (options.help || !options.inputPath) {
     printHelp();
     process.exit(options.help ? 0 : 1);

--- a/scripts/smoke-runtime-bundle.mjs
+++ b/scripts/smoke-runtime-bundle.mjs
@@ -1,0 +1,38 @@
+import { pathToFileURL } from "node:url";
+
+import {
+  getPackageVersion,
+  readPackageJson,
+  resolveRuntimeBundlePaths
+} from "./lib/xlsx2md-runtime-bundle.mjs";
+
+const ROOT = process.cwd();
+
+async function main() {
+  const packageJson = await readPackageJson(ROOT);
+  const expectedVersion = getPackageVersion(packageJson);
+  const { runtimePath } = resolveRuntimeBundlePaths(ROOT);
+  const runtime = await import(`${pathToFileURL(runtimePath).href}?smoke=${Date.now()}`);
+
+  if (runtime.version !== expectedVersion) {
+    throw new Error(`Runtime version mismatch: expected ${expectedVersion}, got ${runtime.version}`);
+  }
+  if (!Array.isArray(runtime.embeddedCorePaths) || runtime.embeddedCorePaths.length === 0) {
+    throw new Error("Runtime bundle does not expose embeddedCorePaths.");
+  }
+
+  const api = runtime.loadXlsx2mdRuntime({ reset: true });
+  if (!api || typeof api.parseWorkbook !== "function") {
+    throw new Error("Runtime bundle did not expose xlsx2md.parseWorkbook.");
+  }
+  if (!api.markdownOptions?.OUTPUT_MODES?.includes("display")) {
+    throw new Error("Runtime bundle did not expose markdown option definitions.");
+  }
+
+  console.log(`[smoke:runtime] ${runtime.version} ok`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/stage-runtime-release-assets.mjs
+++ b/scripts/stage-runtime-release-assets.mjs
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  RUNTIME_BUNDLE_BASENAME,
+  RUNTIME_BUNDLE_JSON,
+  RUNTIME_BUNDLE_MJS,
+  createRuntimeBundleMetadata,
+  getPackageVersion,
+  readPackageJson,
+  resolveRuntimeBundlePaths
+} from "./lib/xlsx2md-runtime-bundle.mjs";
+
+const ROOT = process.cwd();
+const RELEASE_ASSETS_DIR = path.resolve(ROOT, "release-assets");
+
+function resolveReleaseVersion(packageVersion) {
+  const tagName = process.env.TAG_NAME || "";
+  if (!tagName) {
+    return packageVersion;
+  }
+  if (!tagName.startsWith("v")) {
+    throw new Error(`Release tag must start with "v": ${tagName}`);
+  }
+  const version = tagName.slice(1);
+  if (version !== packageVersion && !version.startsWith(`${packageVersion}.`)) {
+    throw new Error(
+      `Release tag version (${version}) must match package.json version (${packageVersion}) or add a dot suffix.`
+    );
+  }
+  return version;
+}
+
+async function copyAsset(sourcePath, targetName) {
+  const targetPath = path.resolve(RELEASE_ASSETS_DIR, targetName);
+  await fs.copyFile(sourcePath, targetPath);
+  console.log(`[stage:runtime-release] staged ${path.relative(ROOT, targetPath)}`);
+}
+
+async function main() {
+  const packageJson = await readPackageJson(ROOT);
+  const packageVersion = getPackageVersion(packageJson);
+  const releaseVersion = resolveReleaseVersion(packageVersion);
+  const { runtimePath } = resolveRuntimeBundlePaths(ROOT);
+  const releaseRuntimeName = `${RUNTIME_BUNDLE_BASENAME}-${releaseVersion}.mjs`;
+  const releaseMetadataName = `${RUNTIME_BUNDLE_BASENAME}-${releaseVersion}.json`;
+
+  await fs.mkdir(RELEASE_ASSETS_DIR, { recursive: true });
+  await copyAsset(runtimePath, releaseRuntimeName);
+
+  const releaseMetadataPath = path.resolve(RELEASE_ASSETS_DIR, releaseMetadataName);
+  const releaseMetadata = {
+    ...createRuntimeBundleMetadata(packageVersion),
+    releaseVersion,
+    runtimeAsset: releaseRuntimeName
+  };
+  await fs.writeFile(releaseMetadataPath, JSON.stringify(releaseMetadata, null, 2) + "\n", "utf8");
+  console.log(`[stage:runtime-release] staged ${path.relative(ROOT, releaseMetadataPath)}`);
+
+  console.log(`[stage:runtime-release] source files: ${RUNTIME_BUNDLE_MJS}, ${RUNTIME_BUNDLE_JSON}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/tests/xlsx2md-cli.test.js
+++ b/tests/xlsx2md-cli.test.js
@@ -115,6 +115,18 @@ describe("xlsx2md cli", () => {
     expect(result.stdout).toContain("Exit codes:");
   });
 
+  it("prints version and exits successfully", async () => {
+    const result = await execFileAsync(process.execPath, [
+      path.resolve(__dirname, "../scripts/miku-xlsx2md-cli.mjs"),
+      "--version"
+    ], {
+      cwd: path.resolve(__dirname, "..")
+    });
+
+    expect(result.stdout.trim()).toBe("1.0.0");
+    expect(result.stderr).toBe("");
+  });
+
   it("fails for an unknown option", async () => {
     await expect(execFileAsync(process.execPath, [
       path.resolve(__dirname, "../scripts/miku-xlsx2md-cli.mjs"),


### PR DESCRIPTION
## 概要

`miku-xlsx2md` の upstream runtime bundle を GitHub Release asset として公開するための build / smoke / staging / workflow を追加しました。

あわせて、CLI の基本契約として `--version` を追加し、`package.json` に `version: 1.0.0` を設定しています。

## 変更内容

- runtime bundle 生成用 script を追加
  - `scripts/build-runtime-bundle.mjs`
  - `scripts/lib/xlsx2md-runtime-bundle.mjs`
  - `scripts/smoke-runtime-bundle.mjs`
  - `scripts/stage-runtime-release-assets.mjs`

- runtime bundle release workflow を追加
  - `.github/workflows/release-runtime-bundle.yml`
  - `v*` tag push で build / test / runtime bundle build / smoke / staging / GitHub Release upload を実行

- runtime release asset contract を追加
  - local artifact:
    - `bundle/miku-xlsx2md-runtime.mjs`
    - `bundle/miku-xlsx2md-runtime.json`
  - GitHub Release asset:
    - `miku-xlsx2md-runtime-<version>.mjs`
    - `miku-xlsx2md-runtime-<version>.json`

- release 用 metadata を versioned asset 名に対応
  - `runtimeAsset` が `miku-xlsx2md-runtime-<version>.mjs` を指す
  - `releaseVersion` を metadata に追加

- CLI の version 表示を追加
  - `--version` を追加
  - help 表示に `--version` を追加
  - `tests/xlsx2md-cli.test.js` に version 表示の回帰テストを追加

- package / docs / ignore 設定を更新
  - `package.json` に `version: 1.0.0` を追加
  - `build:core`, `build:runtime`, `smoke:runtime`, `stage:runtime-release` scripts を追加
  - `bundle/` と `release-assets/` を `.gitignore` に追加
  - README / TODO に runtime bundle 運用を追記

## 確認事項

- ローカルで以下の確認を実施済み
  - `node scripts/miku-xlsx2md-cli.mjs --help`
  - `node scripts/miku-xlsx2md-cli.mjs --version`
  - `npm run test:unit -- tests/xlsx2md-cli.test.js`
  - `npm run build`
  - `npm run build:runtime`
  - `npm run smoke:runtime`
  - `npm run stage:runtime-release`
  - `TAG_NAME=v1.0.0.1 npm run stage:runtime-release`

- 実際の `v*` tag push による GitHub Release asset upload は未確認