### PR TITLE
main リポジトリの検証ログを TODO に記録する

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,3 +57,14 @@ Web App repository owns:
 - Web smoke tests
 - Web release assets
 - vendored upstream runtime artifact used by the browser app
+
+## Verification Log
+
+- [x] 2026-05-17 `npm test`
+  - Passed: 35 test files, 334 tests
+- [x] 2026-05-17 `npm run build:runtime`
+  - Generated ignored local runtime files under `bundle/`
+- [x] 2026-05-17 `npm run smoke:runtime`
+  - Passed for version `1.0.0`
+- [x] 2026-05-17 `npm run stage:runtime-release`
+  - Staged ignored local release assets under `release-assets/`


### PR DESCRIPTION
## 概要

`miku-xlsx2md` main リポジトリの Web 分離後の検証結果を `TODO.md` に記録します。

## 変更内容

- `TODO.md` に `Verification Log` セクションを追加
- `npm test` の通過結果を記録
  - 35 test files
  - 334 tests
- runtime bundle 関連コマンドの通過結果を記録
  - `npm run build:runtime`
  - `npm run smoke:runtime`
  - `npm run stage:runtime-release`
- 生成物の扱いを記録
  - `bundle/`
  - `release-assets/`

## 確認事項

- `npm test` 実行済み
- `npm run build:runtime` 実行済み
- `npm run smoke:runtime` 実行済み
- `npm run stage:runtime-release` 実行済み