### PR TITLE
miku-xlsx2md のバージョンを 1.2.3 に更新

### DIFF
--- a/docs/xlsx2md-front-matter.md
+++ b/docs/xlsx2md-front-matter.md
@@ -26,7 +26,7 @@ title: "sales.xlsx"
 type: converted
 conversion:
   tool: miku-xlsx2md
-  version: "1.2.2"
+  version: "1.2.3"
   output_mode: display
   formatting_mode: github
   table_detection_mode: balanced

--- a/docs/xlsx2md-spec.md
+++ b/docs/xlsx2md-spec.md
@@ -271,7 +271,7 @@ title: "sales.xlsx"
 type: converted
 conversion:
   tool: miku-xlsx2md
-  version: "1.2.2"
+  version: "1.2.3"
   output_mode: display
   formatting_mode: github
   table_detection_mode: balanced

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-xlsx2md",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-xlsx2md",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "devDependencies": {
         "@xmldom/xmldom": "^0.9.9",
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-xlsx2md",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/xlsx2md-cli.test.js
+++ b/tests/xlsx2md-cli.test.js
@@ -131,7 +131,7 @@ describe("xlsx2md cli", () => {
       cwd: path.resolve(__dirname, "..")
     });
 
-    expect(result.stdout.trim()).toBe("1.2.2");
+    expect(result.stdout.trim()).toBe("1.2.3");
     expect(result.stderr).toBe("");
   });
 


### PR DESCRIPTION
## 概要

`miku-xlsx2md` のパッケージバージョンを `1.2.3` に更新します。

## 変更内容

- `package.json` と `package-lock.json` のバージョンを `1.2.3` に更新
- CLI の `--version` テスト期待値を `1.2.3` に更新
- front matter の仕様ドキュメントと出力例に記載されるバージョンを `1.2.3` に更新

## 確認

- `npm test`