### PR TITLE
XLSX のコメント / メモ / スレッドコメントを Markdown に反映する

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Links:
 
 ## What is this?
 
-`miku-xlsx2md` reads `.xlsx` files locally and extracts prose, tables, images, chart information, shape source data, hyperlinks, rich text, and formula-derived values into Markdown and related artifacts.
+`miku-xlsx2md` reads `.xlsx` files locally and extracts prose, tables, images, chart information, shape source data, comments, notes, threaded comments, hyperlinks, rich text, and formula-derived values into Markdown and related artifacts.
 
 The conversion goal is meaningful Markdown extraction, not exact visual reproduction of Excel.
 
@@ -21,7 +21,7 @@ Generated combined Markdown includes workbook-level YAML front matter with the a
 ## Features
 
 - Converts all sheets in a workbook in one pass
-- Extracts prose, tables, images, chart configuration data, and shape source data
+- Extracts prose, tables, images, chart configuration data, shape source data, comments, notes, and threaded comments
 - Detects table-like regions using borders and value groupings
 - Supports `display / raw / both` output modes
 - Supports `plain / github` formatting modes

--- a/docs/xlsx2md-spec.md
+++ b/docs/xlsx2md-spec.md
@@ -971,6 +971,13 @@ ImageAsset
   - 日付系表示値の一部文字列化
 - `xl/worksheets/_rels/sheet*.xml.rels`
   - worksheet から drawing への解決
+  - worksheet から comments / threaded comments への解決
+- `xl/comments*.xml`
+  - セルに紐づく従来型メモ / notes
+- `xl/threadedComments/threadedComment*.xml`
+  - セルに紐づくスレッドコメント本文
+- `xl/persons/person*.xml`
+  - threaded comments の personId から表示名への解決
 - `xl/drawings/*.xml`
   - 画像アンカー位置
   - グラフアンカー位置
@@ -1032,7 +1039,6 @@ ImageAsset
 - array formula
 - dynamic array spill
 - 条件付き書式
-- コメント / メモ
 - データ検証
 - ピボットテーブル
 - グラフの完全再描画や SVG 化
@@ -1085,7 +1091,6 @@ ImageAsset
 - `calcChain.xml` を用いた計算順最適化
 - rich text の装飾差分保持
 - 条件付き書式
-- コメント / メモ
 - データ検証
 
 低優先:

--- a/src/ts/core.ts
+++ b/src/ts/core.ts
@@ -85,6 +85,7 @@
     images: ParsedImageAsset[];
     charts: ParsedChartAsset[];
     shapes: ParsedShapeAsset[];
+    comments: ParsedCellComment[];
     maxRow: number;
     maxCol: number;
   };
@@ -135,6 +136,14 @@
     svgFilename: string | null;
     svgPath: string | null;
     svgData: Uint8Array | null;
+  };
+
+  type ParsedCellComment = {
+    address: string;
+    kind: "note" | "threaded";
+    author: string;
+    text: string;
+    dateTime: string;
   };
 
   type ParsedRangeRef = {
@@ -234,6 +243,7 @@
       merges: number;
       images: number;
       charts: number;
+      comments: number;
       cells: number;
       tableScores: TableScoreDetail[];
       formulaDiagnostics: FormulaDiagnostic[];

--- a/src/ts/markdown-export.ts
+++ b/src/ts/markdown-export.ts
@@ -35,6 +35,7 @@
       merges: number;
       images: number;
       charts: number;
+      comments: number;
       cells: number;
       tableScores: TableScoreDetail[];
       formulaDiagnostics: FormulaDiagnostic[];
@@ -176,6 +177,7 @@
       `Merged ranges: ${markdownFile.summary.merges}`,
       `Images: ${markdownFile.summary.images}`,
       `Charts: ${markdownFile.summary.charts}`,
+      `Comments: ${markdownFile.summary.comments || 0}`,
       `Analyzed cells: ${markdownFile.summary.cells}`,
       ...FORMULA_STATUSES.map((status) => `Formula ${status}: ${formulaCounts[status]}`),
       ...markdownFile.summary.tableScores.map((detail) => `Table candidate ${detail.range}: score ${detail.score} / ${detail.reasons.join(", ")}`)

--- a/src/ts/sheet-markdown.ts
+++ b/src/ts/sheet-markdown.ts
@@ -120,6 +120,14 @@
     svgData: Uint8Array | null;
   };
 
+  type ParsedCellComment = {
+    address: string;
+    kind: "note" | "threaded";
+    author: string;
+    text: string;
+    dateTime: string;
+  };
+
   type ParsedSheet = {
     name: string;
     index: number;
@@ -128,6 +136,7 @@
     images: ParsedImageAsset[];
     charts: ParsedChartAsset[];
     shapes: ParsedShapeAsset[];
+    comments: ParsedCellComment[];
   };
 
   type ParsedWorkbook = {
@@ -191,6 +200,7 @@
     imageSection: string;
     chartSection: string;
     shapeSection: string;
+    commentSection: string;
   };
 
   type CellMarkdownValues = {
@@ -230,6 +240,7 @@
       merges: number;
       images: number;
       charts: number;
+      comments: number;
       cells: number;
       tableScores: Array<{
         range: string;
@@ -842,6 +853,28 @@
         : "";
     }
 
+    function createCommentSectionEntry(comment: ParsedCellComment, index: number): string {
+      const label = `comment-${index + 1}`;
+      const metadata = [
+        comment.address,
+        comment.kind,
+        comment.author ? `author=${comment.author}` : "",
+        comment.dateTime ? `date=${comment.dateTime}` : ""
+      ].filter(Boolean).join("; ");
+      return `- [${label}] (${metadata}) ${comment.text}`;
+    }
+
+    function renderCommentSection(comments: ParsedCellComment[] = []): string {
+      return comments.length > 0
+        ? [
+          "",
+          "### Comments",
+          "",
+          ...comments.map((comment, index) => createCommentSectionEntry(comment, index))
+        ].join("\n\n")
+        : "";
+    }
+
     function createFormulaDiagnostics(sheet: ParsedSheet): MarkdownFile["summary"]["formulaDiagnostics"] {
       return sheet.cells
         .filter((cell) => !!cell.formulaText && cell.resolutionStatus !== null)
@@ -1047,6 +1080,7 @@
       const chartSection = renderChartSection(charts);
       const includeShapeDetails = resolvedOptions.includeShapeDetails;
       const shapeSection = renderShapeSection(shapes, shapeBlocks, includeShapeDetails);
+      const commentSection = renderCommentSection(sheet.comments || []);
       return {
         resolvedOptions,
         charts,
@@ -1061,7 +1095,8 @@
         body,
         imageSection,
         chartSection,
-        shapeSection
+        shapeSection,
+        commentSection
       };
     }
 
@@ -1072,6 +1107,7 @@
         `## Sheet: ${sheet.name}`,
         "",
         state.body || "_No extractable body content was found._",
+        state.commentSection,
         state.chartSection,
         state.shapeSection,
         state.imageSection
@@ -1090,6 +1126,7 @@
         merges: sheet.merges.length,
         images: sheet.images.length,
         charts: state.charts.length,
+        comments: (sheet.comments || []).length,
         cells: sheet.cells.length,
         tableScores: state.tables.map((table) => ({
           range: deps.formatRange(table.startRow, table.startCol, table.endRow, table.endCol),
@@ -1140,6 +1177,7 @@
       renderImageSection,
       renderChartSection,
       renderShapeSection,
+      renderCommentSection,
       convertSheetToMarkdown,
       convertWorkbookToMarkdownFiles
     };

--- a/src/ts/worksheet-parser.ts
+++ b/src/ts/worksheet-parser.ts
@@ -103,6 +103,14 @@
     svgData: Uint8Array | null;
   };
 
+  type ParsedCellComment = {
+    address: string;
+    kind: "note" | "threaded";
+    author: string;
+    text: string;
+    dateTime: string;
+  };
+
   type ParsedCell = {
     address: string;
     row: number;
@@ -141,6 +149,7 @@
     images: ParsedImageAsset[];
     charts: ParsedChartAsset[];
     shapes: ParsedShapeAsset[];
+    comments: ParsedCellComment[];
     maxRow: number;
     maxCol: number;
   };
@@ -261,6 +270,106 @@
       }
     }
     return hyperlinks;
+  }
+
+  function extractRichTextPlainText(element: Element | null | undefined, deps: Pick<WorksheetParserDependencies, "getTextContent">): string {
+    if (!element) return "";
+    const textNodes = Array.from(element.getElementsByTagName("t"));
+    if (textNodes.length > 0) {
+      return textNodes.map((node) => deps.getTextContent(node)).join("");
+    }
+    return deps.getTextContent(element);
+  }
+
+  function parseLegacyCommentsXml(
+    xmlText: string,
+    deps: Pick<WorksheetParserDependencies, "xmlToDocument" | "getTextContent">
+  ): ParsedCellComment[] {
+    const doc = deps.xmlToDocument(xmlText);
+    const authors = Array.from(doc.getElementsByTagName("author")).map((node) => deps.getTextContent(node).trim());
+    return Array.from(doc.getElementsByTagName("comment")).map((commentElement) => {
+      const authorId = Number(commentElement.getAttribute("authorId") || 0);
+      return {
+        address: (commentElement.getAttribute("ref") || "").trim(),
+        kind: "note",
+        author: authors[authorId] || "",
+        text: extractRichTextPlainText(commentElement.getElementsByTagName("text")[0] || null, deps).trim(),
+        dateTime: ""
+      } satisfies ParsedCellComment;
+    }).filter((comment) => !!comment.address && !!comment.text);
+  }
+
+  function parsePersonDisplayNames(
+    files: Map<string, Uint8Array>,
+    deps: Pick<WorksheetParserDependencies, "xmlToDocument" | "decodeXmlText">
+  ): Map<string, string> {
+    const persons = new Map<string, string>();
+    for (const [path, bytes] of files.entries()) {
+      if (!/^xl\/persons\/person[^/]*\.xml$/u.test(path)) continue;
+      const doc = deps.xmlToDocument(deps.decodeXmlText(bytes));
+      for (const personElement of Array.from(doc.getElementsByTagName("person"))) {
+        const id = (personElement.getAttribute("id") || "").trim();
+        const displayName = (personElement.getAttribute("displayName") || "").trim();
+        if (id && displayName) {
+          persons.set(id, displayName);
+        }
+      }
+    }
+    return persons;
+  }
+
+  function parseThreadedCommentsXml(
+    xmlText: string,
+    persons: Map<string, string>,
+    deps: Pick<WorksheetParserDependencies, "xmlToDocument" | "getTextContent">
+  ): ParsedCellComment[] {
+    const doc = deps.xmlToDocument(xmlText);
+    return Array.from(doc.getElementsByTagName("threadedComment")).map((commentElement) => {
+      const personId = (commentElement.getAttribute("personId") || "").trim();
+      return {
+        address: (commentElement.getAttribute("ref") || "").trim(),
+        kind: "threaded",
+        author: persons.get(personId) || personId,
+        text: extractRichTextPlainText(commentElement, deps).trim(),
+        dateTime: (commentElement.getAttribute("dT") || "").trim()
+      } satisfies ParsedCellComment;
+    }).filter((comment) => !!comment.address && !!comment.text);
+  }
+
+  function isLegacyCommentRelationship(type: string): boolean {
+    return /\/comments$/u.test(type);
+  }
+
+  function isThreadedCommentRelationship(type: string): boolean {
+    return /\/threadedComment$/u.test(type) || /\/threadedComments$/u.test(type);
+  }
+
+  function parseWorksheetComments(
+    files: Map<string, Uint8Array>,
+    sheetPath: string,
+    deps: Pick<WorksheetParserDependencies, "xmlToDocument" | "decodeXmlText" | "getTextContent" | "parseRelationshipEntries" | "buildRelsPath" | "parseCellAddress">
+  ): ParsedCellComment[] {
+    const comments: ParsedCellComment[] = [];
+    const relsPath = deps.buildRelsPath(sheetPath);
+    const relEntries = deps.parseRelationshipEntries(files, relsPath, sheetPath);
+    const persons = parsePersonDisplayNames(files, deps);
+    for (const entry of relEntries.values()) {
+      const bytes = files.get(entry.target);
+      if (!bytes) continue;
+      const xmlText = deps.decodeXmlText(bytes);
+      if (isLegacyCommentRelationship(entry.type)) {
+        comments.push(...parseLegacyCommentsXml(xmlText, deps));
+      } else if (isThreadedCommentRelationship(entry.type)) {
+        comments.push(...parseThreadedCommentsXml(xmlText, persons, deps));
+      }
+    }
+    return comments.sort((left, right) => {
+      const leftPos = deps.parseCellAddress(left.address);
+      const rightPos = deps.parseCellAddress(right.address);
+      if (leftPos.row !== rightPos.row) return leftPos.row - rightPos.row;
+      if (leftPos.col !== rightPos.col) return leftPos.col - rightPos.col;
+      return left.kind.localeCompare(right.kind);
+    });
   }
 
   function hasEnabledBooleanValue(node: Element | null | undefined): boolean {
@@ -610,6 +719,7 @@
     const shapes = deps.parseShapes === false
       ? []
       : deps.parseDrawingShapes(files, sheetName, sheetPath, assetDeps);
+    const comments = parseWorksheetComments(files, sheetPath, deps);
     let maxRow = 0;
     let maxCol = 0;
     for (const cell of cells) {
@@ -630,6 +740,7 @@
       images,
       charts,
       shapes,
+      comments,
       maxRow,
       maxCol
     };
@@ -639,6 +750,10 @@
     extractCellOutputValue,
     expandRangeAddresses,
     parseWorksheetHyperlinks,
+    parseLegacyCommentsXml,
+    parsePersonDisplayNames,
+    parseThreadedCommentsXml,
+    parseWorksheetComments,
     shiftReferenceAddress,
     translateSharedFormula,
     parseWorksheet

--- a/tests/xlsx2md-sheet-markdown.test.js
+++ b/tests/xlsx2md-sheet-markdown.test.js
@@ -324,6 +324,36 @@ describe("xlsx2md sheet markdown", () => {
     expect(chartSection).toContain("    - values: Sheet1!B2:B5");
   });
 
+  it("renders comments as a separate sheet section and counts them in summary", () => {
+    const module = bootSheetMarkdown();
+    const api = module.createSheetMarkdownApi(createDeps({
+      renderNarrativeBlock: (block) => block.lines.join("\n")
+    }));
+    const workbook = { name: "book.xlsx", sheets: [] };
+    const sheet = {
+      name: "Sheet1",
+      index: 1,
+      cells: [
+        { address: "A1", row: 1, col: 1, outputValue: "Cell", rawValue: "Cell", formulaText: "", resolutionStatus: null, resolutionSource: null }
+      ],
+      merges: [],
+      images: [],
+      charts: [],
+      shapes: [],
+      comments: [
+        { address: "A1", kind: "note", author: "Alice", text: "Legacy note", dateTime: "" },
+        { address: "B2", kind: "threaded", author: "Bob", text: "Threaded reply", dateTime: "2026-07-02T10:00:00Z" }
+      ]
+    };
+
+    const result = api.convertSheetToMarkdown(workbook, sheet, {});
+
+    expect(result.markdown).toContain("### Comments");
+    expect(result.markdown).toContain("- [comment-1] (A1; note; author=Alice) Legacy note");
+    expect(result.markdown).toContain("- [comment-2] (B2; threaded; author=Bob; date=2026-07-02T10:00:00Z) Threaded reply");
+    expect(result.summary.comments).toBe(2);
+  });
+
   it("renders ungrouped shapes after grouped shape blocks", () => {
     const module = bootSheetMarkdown();
     const api = module.createSheetMarkdownApi(createDeps({

--- a/tests/xlsx2md-worksheet-parser.test.js
+++ b/tests/xlsx2md-worksheet-parser.test.js
@@ -61,10 +61,17 @@ function createDeps() {
         const target = node.getAttribute("Target") || "";
         if (!id || !target) continue;
         const targetMode = node.getAttribute("TargetMode") || "";
+        const baseParts = String(sourcePath || "").split("/").slice(0, -1);
+        const parts = target.startsWith("/") ? [] : baseParts;
+        for (const part of target.split("/")) {
+          if (!part || part === ".") continue;
+          if (part === "..") parts.pop();
+          else parts.push(part);
+        }
         entries.set(id, {
           target: targetMode === "External"
             ? target
-            : `${String(sourcePath || "").split("/").slice(0, -1).join("/")}/${target}`.replace(/\/\.\//g, "/"),
+            : parts.join("/"),
           targetMode,
           type: node.getAttribute("Type") || ""
         });
@@ -231,5 +238,56 @@ describe("xlsx2md worksheet parser", () => {
       tooltip: "go",
       display: ""
     });
+  });
+
+  it("parses legacy notes and threaded comments from worksheet relationships", () => {
+    const api = bootWorksheetParser();
+    const deps = createDeps();
+    const worksheetXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        <sheetData>
+          <row r="1"><c r="A1" t="inlineStr"><is><t>Cell</t></is></c></row>
+        </sheetData>
+      </worksheet>`;
+    const commentsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        <authors><author>Alice</author></authors>
+        <commentList>
+          <comment ref="A1" authorId="0"><text><r><t>Legacy note</t></r></text></comment>
+        </commentList>
+      </comments>`;
+    const personsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+        <person id="{person-1}" displayName="Bob"/>
+      </personList>`;
+    const threadedXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <ThreadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+        <threadedComment ref="B2" personId="{person-1}" dT="2026-07-02T10:00:00Z"><text>Threaded reply</text></threadedComment>
+      </ThreadedComments>`;
+    const files = new Map([
+      ["xl/worksheets/sheet1.xml", new TextEncoder().encode(worksheetXml)],
+      ["xl/comments1.xml", new TextEncoder().encode(commentsXml)],
+      ["xl/persons/person.xml", new TextEncoder().encode(personsXml)],
+      ["xl/threadedComments/threadedComment1.xml", new TextEncoder().encode(threadedXml)],
+      ["xl/worksheets/_rels/sheet1.xml.rels", new TextEncoder().encode(
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+        '<Relationship Id="comments" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments1.xml"/>' +
+        '<Relationship Id="threaded" Type="http://schemas.microsoft.com/office/2017/10/relationships/threadedComment" Target="../threadedComments/threadedComment1.xml"/>' +
+        "</Relationships>"
+      )]
+    ]);
+
+    const sheet = api.parseWorksheet(files, "Sheet1", "xl/worksheets/sheet1.xml", 1, [], [{
+      borders: { top: false, bottom: false, left: false, right: false },
+      numFmtId: 0,
+      formatCode: "General",
+      textStyle: { bold: false, italic: false, strike: false, underline: false }
+    }], deps);
+
+    expect(sheet.comments).toEqual([
+      { address: "A1", kind: "note", author: "Alice", text: "Legacy note", dateTime: "" },
+      { address: "B2", kind: "threaded", author: "Bob", text: "Threaded reply", dateTime: "2026-07-02T10:00:00Z" }
+    ]);
   });
 });


### PR DESCRIPTION
## 概要

XLSX 変換でセルに紐づくコメント、従来型メモ、スレッドコメントを抽出し、Markdown のシート内コメントセクションと summary に反映します。

## 変更内容

- worksheet relationships から comments / threaded comments / persons パーツを解決し、セル番地、種別、author、date、本文を抽出
- 各シートの Markdown に `### Comments` セクションを追加し、`comment-N` ラベル付きのリストとしてコメントを出力
- sheet summary と summary text にコメント件数を追加
- README と仕様書にコメント / メモ / スレッドコメント対応を反映し、未対応リストからコメント / メモを削除
- 旧メモとスレッドコメントの parser テスト、Markdown 出力と summary 件数のテストを追加

## 検証

- `npm test`