### PR TITLE
miku-xlsx2md のバージョンを 1.3.0 に更新

### DIFF
--- a/docs/xlsx2md-front-matter.md
+++ b/docs/xlsx2md-front-matter.md
@@ -26,7 +26,7 @@ title: "sales.xlsx"
 type: converted
 conversion:
   tool: miku-xlsx2md
-  version: "1.2.3"
+  version: "1.3.0"
   output_mode: display
   formatting_mode: github
   table_detection_mode: balanced

--- a/docs/xlsx2md-spec.md
+++ b/docs/xlsx2md-spec.md
@@ -271,7 +271,7 @@ title: "sales.xlsx"
 type: converted
 conversion:
   tool: miku-xlsx2md
-  version: "1.2.3"
+  version: "1.3.0"
   output_mode: display
   formatting_mode: github
   table_detection_mode: balanced

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-xlsx2md",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-xlsx2md",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "devDependencies": {
         "@xmldom/xmldom": "^0.9.9",
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-xlsx2md",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/xlsx2md-cli.test.js
+++ b/tests/xlsx2md-cli.test.js
@@ -131,7 +131,7 @@ describe("xlsx2md cli", () => {
       cwd: path.resolve(__dirname, "..")
     });
 
-    expect(result.stdout.trim()).toBe("1.2.3");
+    expect(result.stdout.trim()).toBe("1.3.0");
     expect(result.stderr).toBe("");
   });
 

--- a/tests/xlsx2md-markdown-export.test.js
+++ b/tests/xlsx2md-markdown-export.test.js
@@ -308,7 +308,7 @@ describe("xlsx2md markdown export", () => {
         }
       }],
       {
-        toolVersion: "1.2.3",
+        toolVersion: "1.3.0",
         shapeDetails: "include"
       }
     );
@@ -319,7 +319,7 @@ describe("xlsx2md markdown export", () => {
       "type: converted",
       "conversion:",
       "  tool: miku-xlsx2md",
-      "  version: \"1.2.3\"",
+      "  version: \"1.3.0\"",
       "  output_mode: both",
       "  formatting_mode: github",
       "  table_detection_mode: border",


### PR DESCRIPTION
## 概要

`miku-xlsx2md` の package version と、関連する front matter 例および version 期待値テストを `1.3.0` に更新します。

## 変更内容

- `package.json` と `package-lock.json` の version を `1.3.0` に更新
- front matter 仕様例の `conversion.version` を `1.3.0` に更新
- CLI `--version` テストと Markdown export の version 期待値を `1.3.0` に更新

## 検証

- `npm test`